### PR TITLE
receiveValue with weak self closure

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -143,7 +143,9 @@ where State: Equatable {
             receiveCompletion: { [weak self] _ in
                 self?.cancellables.removeValue(forKey: id)
             },
-            receiveValue: self.send
+            receiveValue: { [weak self] action in
+                self?.send(action: action)
+            }
         )
         self.cancellables[id] = cancellable
     }


### PR DESCRIPTION
This allows store to be released before effect is complete, without creating a retain cycle. Ordinarily store's lifetime is the lifetime of the app, so this should not be an issue for single-store apps, but a weak reference to self should used here regardless. Additionally, this will now avoid a possible retain cycle if using multiple short-lived stores, such as one per component.