### PR TITLE
Allow specifying transaction for Update

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -202,11 +202,11 @@ where State: Equatable {
         // If no change has occurred, we avoid setting the property
         // so that body does not need to be reevaluated.
         if self.state != next.state {
-            // If transaction is specified by update, set transaction
-            // then set state.
+            // If transaction is specified by update, set state with
+            // that transaction.
             //
-            // Otherwise, if transaction is `nil`, just set `state`, and
-            // defer to global transaction value.
+            // Otherwise, if transaction is nil, just set state, and
+            // defer to global transaction.
             if let transaction = next.transaction {
                 withTransaction(transaction) {
                     self.state = next.state

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -20,8 +20,10 @@ where State: Equatable {
     /// Default is an `Empty` publisher (no effects)
     public var fx: Fx<Action>
     /// The transaction that should be set during this update.
-    /// Allows update to drive explicit animations.
-    /// If left `nil`, this `Update` defers to the global transaction.
+    /// Store uses this value to set the transaction while updating state,
+    /// allowing you to drive explicit animations from your update function.
+    /// If left `nil`, store will defer to the global transaction
+    /// for this state update.
     /// See https://developer.apple.com/documentation/swiftui/transaction
     public var transaction: Transaction?
 
@@ -36,7 +38,7 @@ where State: Equatable {
         self.transaction = transaction
     }
 
-    /// Set transaction for this `Update`.
+    /// Set transaction for this update
     /// - Returns a new `Update`
     public func transaction(_ transaction: Transaction) -> Self {
         var this = self
@@ -44,7 +46,8 @@ where State: Equatable {
         return this
     }
 
-    /// Set `Transaction` and `Animation` for this `Update`.
+    /// Set explicit animation for this update.
+    /// Sets new transaction with specified animation.
     /// - Returns a new `Update`
     public func animation(_ animation: Animation? = .default) -> Self {
         var this = self

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -19,10 +19,9 @@ where State: Equatable {
     /// `Fx` for this update.
     /// Default is an `Empty` publisher (no effects)
     public var fx: Fx<Action>
-    /// The transaction that store should assign to this update.
-    /// Setting this allows you to drive animations from the update function,
-    /// instead of wrapping calls to send in `withAnimation`.
-    /// If left nil, this update will defer to the global transaction.
+    /// The transaction that should be set during this update.
+    /// Allows update to drive explicit animations.
+    /// If left `nil`, this `Update` defers to the global transaction.
     /// See https://developer.apple.com/documentation/swiftui/transaction
     public var transaction: Transaction?
 
@@ -37,15 +36,15 @@ where State: Equatable {
         self.transaction = transaction
     }
 
-    /// Set this Update's transaction.
+    /// Set transaction for this `Update`.
     /// - Returns a new `Update`
-    public func transaction(_ transaction: Transaction?) -> Self {
+    public func transaction(_ transaction: Transaction) -> Self {
         var this = self
         this.transaction = transaction
         return this
     }
 
-    /// Set this Update's transaction and animation
+    /// Set `Transaction` and `Animation` for this `Update`.
     /// - Returns a new `Update`
     public func animation(_ animation: Animation? = .default) -> Self {
         var this = self


### PR DESCRIPTION
Allow updates to specify transaction under which state update should take place.

This allows update functions to drive explicit animations. Animations, as well as state changes, can be specified.