### PR TITLE
Receive Fx on main thread

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -172,19 +172,33 @@ where State: Equatable {
         // the effect, and then removes it, so we don't have a cancellables
         // memory leak.
         let id = UUID()
-        var isComplete = false
-        let cancellable = fx.sink(
-            receiveCompletion: { [weak self] _ in
-                isComplete = true
-                self?.cancellables.removeValue(forKey: id)
-            },
-            receiveValue: { [weak self] action in
-                self?.send(action: action)
-            }
-        )
-        if !isComplete {
-            self.cancellables[id] = cancellable
-        }
+        // Receive Fx on main thread. This does two important things:
+        //
+        // First, SwiftUI requires that any state mutations that would change
+        // views happen on the main thread. Receiving on main ensures that
+        // all fx-driven state transitions happen on main, even if the
+        // publisher is off-main-thread.
+        //
+        // Second, if we didn't schedule receive on main, it would be possible
+        // for publishers to complete immediately, causing receiveCompletion
+        // to attempt to remove the publisher from `cancellables` before
+        // it is added. By scheduling to receive publisher on main,
+        // we force publisher to complete on next tick, ensuring that it
+        // is always first added, then removed from `cancellables`.
+        let cancellable = fx
+            .receive(
+                on: DispatchQueue.main,
+                options: .init(qos: .userInteractive)
+            )
+            .sink(
+                receiveCompletion: { [weak self] _ in
+                    self?.cancellables.removeValue(forKey: id)
+                },
+                receiveValue: { [weak self] action in
+                    self?.send(action: action)
+                }
+            )
+        self.cancellables[id] = cancellable
     }
 
     /// Send an action to the store to update state and generate effects.

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -101,10 +101,17 @@ final class ObservableStoreTests: XCTestCase {
         store.send(action: .increment)
         store.send(action: .increment)
         store.send(action: .increment)
-        XCTAssertEqual(
-            store.cancellables.count,
-            0,
-            "cancellables removed when publisher completes"
+        let expectation = XCTestExpectation(
+            description: "cancellable removed when publisher completes"
         )
+        DispatchQueue.main.async {
+            XCTAssertEqual(
+                store.cancellables.count,
+                0,
+                "cancellables removed when publisher completes"
+            )
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
     }
 }

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -11,8 +11,7 @@ final class ObservableStoreTests: XCTestCase {
         }
 
         /// Services like API methods go here
-        struct Environment {
-        }
+        struct Environment {}
 
         /// State update function
         static func update(
@@ -90,6 +89,22 @@ final class ObservableStoreTests: XCTestCase {
             store.state.editor.input.text,
             "floop",
             "specialized binding sets deep property"
+        )
+    }
+
+    func testEmptyFxRemovedOnComplete() {
+        let store = Store(
+            update: AppState.update,
+            state: AppState(),
+            environment: AppState.Environment()
+        )
+        store.send(action: .increment)
+        store.send(action: .increment)
+        store.send(action: .increment)
+        XCTAssertEqual(
+            store.cancellables.count,
+            0,
+            "cancellables removed when publisher completes"
         )
     }
 }


### PR DESCRIPTION
Receive Fx on main thread. This does two important things:

First, SwiftUI requires that any state mutations that would change views happen on the main thread. Receiving on main ensures that all fx-driven state transitions happen on main, even if the publisher is off-main-thread.

Second, if we don’t schedule to receive on main, it is possible for publishers to complete immediately, causing receiveCompletion to attempt to remove the publisher from `cancellables` before it is added. This was happening with `Empty()` publishers returned by default when you do not specify `Update(fx:)`.

By scheduling to receive publisher on main, we force publisher to complete on next tick, ensuring that it is always first added, then removed from `cancellables`.

This is an alternative to the flag-based approach in https://github.com/gordonbrander/ObservableStore/blob/2022-03-12-fx-tests-2/Sources/ObservableStore/ObservableStore.swift#L175.

### More background

Cancellables will cancel themselves they are released (makes sense). This means you must keep cancellables alive for the duration of the lifetime of the publisher by storing them somewhere. In our case, we store them in a map of `[UUID: Cancellable]`.

So anyway, we remove them when publisher completes in the `receiveCompletion`. HOWEVER, it is possible for a publisher to IMMEDIATELY complete during the same tick. This causes the `receiveCompletion` code which removes the cancellable from the map to run BEFORE the cancellable is added to the map. The result is that these immediately-completing cancellables leak, in the sense that they build up and are never removed. Cancellables are very tiny, so we didn't notice the impact on memory, but it is bad hygiene.