### PR TITLE
Introduce `mergeFx`

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -38,6 +38,24 @@ where State: Equatable {
         self.transaction = transaction
     }
 
+    /// Set fx for this update
+    /// This will replace any existing fx for the update.
+    /// - Returns a new `Update`
+    func fx(_ fx: Fx<Action>) -> Update<State, Action> {
+        var this = self
+        this.fx = fx
+        return this
+    }
+
+    /// Merge existing fx in this update with new fx.
+    /// The resulting update will contain an fx publisher
+    /// - Returns a new `Update`
+    func mergeFx(_ fx: Fx<Action>) -> Update<State, Action> {
+        var this = self
+        this.fx = self.fx.merge(with: fx).eraseToAnyPublisher()
+        return this
+    }
+
     /// Set transaction for this update
     /// - Returns a new `Update`
     public func transaction(_ transaction: Transaction) -> Self {
@@ -56,8 +74,13 @@ where State: Equatable {
     }
 
     /// Pipe a state through another update function.
-    /// Merges `fx`.
-    /// Replaces `transaction` with new `Update` transaction.
+    /// Allows you to compose multiple update functions together through
+    /// method chaining.
+    ///
+    /// - Updates state,
+    /// - Merges `fx`.
+    /// - Replaces `transaction` with new `Update` transaction.
+    ///
     /// - Returns a new `Update`
     public func pipe(
         _ through: (State) -> Self

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -38,29 +38,11 @@ where State: Equatable {
         self.transaction = transaction
     }
 
-    /// Set fx for this update
-    /// This will replace any existing fx for the update.
+    /// Merge existing fx together with new fx.
     /// - Returns a new `Update`
-    func fx(_ fx: Fx<Action>) -> Update<State, Action> {
-        var this = self
-        this.fx = fx
-        return this
-    }
-
-    /// Merge existing fx in this update with new fx.
-    /// The resulting update will contain an fx publisher
-    /// - Returns a new `Update`
-    func mergeFx(_ fx: Fx<Action>) -> Update<State, Action> {
+    public func mergeFx(_ fx: Fx<Action>) -> Update<State, Action> {
         var this = self
         this.fx = self.fx.merge(with: fx).eraseToAnyPublisher()
-        return this
-    }
-
-    /// Set transaction for this update
-    /// - Returns a new `Update`
-    public func transaction(_ transaction: Transaction) -> Self {
-        var this = self
-        this.transaction = transaction
         return this
     }
 


### PR DESCRIPTION
Fixes #8.

This PR also removes `Update.transaction(_)` since name conflicts with `Update.transaction` property. Note I decided against adding `fx` for the same reason. I will avoid adding plain old setters for now, since chaining sets is not really the most common need.

If we find we really need more than property setters for simple sets in the future, we may want to add a `map` function instead.