### PR TITLE
Update arg labels for send, subscribe

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -169,7 +169,7 @@ where State: Equatable {
     ///
     /// Holds on to the cancellable until publisher completes.
     /// When publisher completes, removes cancellable.
-    public func subscribe(_ fx: Fx<Action>) {
+    public func subscribe(to fx: Fx<Action>) {
         // Create a UUID for the cancellable.
         // Store cancellable in dictionary by UUID.
         // Remove cancellable from dictionary upon effect completion.
@@ -242,6 +242,6 @@ where State: Equatable {
             }
         }
         // Run effect
-        self.subscribe(next.fx)
+        self.subscribe(to: next.fx)
     }
 }

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -158,7 +158,7 @@ where State: Equatable {
             get: { get(self.state) },
             set: { value in
                 withAnimation(animation) {
-                    self.send(action: tag(value))
+                    self.send(tag(value))
                 }
             }
         )
@@ -169,7 +169,7 @@ where State: Equatable {
     ///
     /// Holds on to the cancellable until publisher completes.
     /// When publisher completes, removes cancellable.
-    public func subscribe(fx: Fx<Action>) {
+    public func subscribe(_ fx: Fx<Action>) {
         // Create a UUID for the cancellable.
         // Store cancellable in dictionary by UUID.
         // Remove cancellable from dictionary upon effect completion.
@@ -200,7 +200,7 @@ where State: Equatable {
                     self?.cancellables.removeValue(forKey: id)
                 },
                 receiveValue: { [weak self] action in
-                    self?.send(action: action)
+                    self?.send(action)
                 }
             )
         self.cancellables[id] = cancellable
@@ -216,7 +216,7 @@ where State: Equatable {
     /// However it also means that publishers which run off-main-thread MUST
     /// make sure that they join the main thread (e.g. with
     /// `.receive(on: DispatchQueue.main)`).
-    public func send(action: Action) {
+    public func send(_ action: Action) {
         // Generate next state and effect
         let next = update(self.state, self.environment, action)
         // Set `state` if changed.
@@ -242,6 +242,6 @@ where State: Equatable {
             }
         }
         // Run effect
-        self.subscribe(fx: next.fx)
+        self.subscribe(next.fx)
     }
 }

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -79,7 +79,7 @@ final class ObservableStoreTests: XCTestCase {
             environment: AppState.Environment()
         )
 
-        store.send(action: .increment)
+        store.send(.increment)
         XCTAssertEqual(store.state.count, 1, "state is advanced")
     }
 
@@ -123,9 +123,9 @@ final class ObservableStoreTests: XCTestCase {
             state: AppState(),
             environment: AppState.Environment()
         )
-        store.send(action: .increment)
-        store.send(action: .increment)
-        store.send(action: .increment)
+        store.send(.increment)
+        store.send(.increment)
+        store.send(.increment)
         let expectation = XCTestExpectation(
             description: "cancellable removed when publisher completes"
         )
@@ -146,8 +146,8 @@ final class ObservableStoreTests: XCTestCase {
             state: AppState(),
             environment: AppState.Environment()
         )
-        store.send(action: .delayIncrement(0.1))
-        store.send(action: .delayIncrement(0.2))
+        store.send(.delayIncrement(0.1))
+        store.send(.delayIncrement(0.2))
         let expectation = XCTestExpectation(
             description: "cancellable removed when publisher completes"
         )
@@ -190,10 +190,10 @@ final class ObservableStoreTests: XCTestCase {
                 }
             )
             .store(in: &self.cancellables)
-        store.send(action: .setCount(10))
-        store.send(action: .setCount(10))
-        store.send(action: .setCount(10))
-        store.send(action: .setCount(10))
+        store.send(.setCount(10))
+        store.send(.setCount(10))
+        store.send(.setCount(10))
+        store.send(.setCount(10))
 
         wait(for: [expectation], timeout: 0.2)
     }
@@ -250,7 +250,7 @@ final class ObservableStoreTests: XCTestCase {
             environment: TestUpdateMergeFxState.Environment()
         )
         store.send(
-            action: .setTitleAndSubtitleViaMergeFx(
+            .setTitleAndSubtitleViaMergeFx(
                 title: "title",
                 subtitle: "subtitle"
             )


### PR DESCRIPTION
Fixes #7

Per https://www.swift.org/documentation/api-design-guidelines/#argument-labels,

> If the first argument forms part of a grammatical phrase, omit its label.

This is the case for `store.send(_)`, so we remove the label.

> When the first argument forms part of a [prepositional phrase](https://en.wikipedia.org/wiki/Adpositional_phrase#Prepositional_phrases), give it an argument label.

We _subscribe to_ a publisher, therefore `store.subscribe(to:)`