### PR TITLE
Create binding form that does not set animation

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -147,12 +147,26 @@ where State: Equatable {
 
     /// Create a binding that can update the store.
     /// Sets send actions to the store, rather than setting values directly.
+    public func binding<Value>(
+        get: @escaping (State) -> Value,
+        tag: @escaping (Value) -> Action
+    ) -> Binding<Value> {
+        Binding(
+            get: { get(self.state) },
+            set: { value in
+                self.send(tag(value))
+            }
+        )
+    }
+
+    /// Create a binding that can update the store.
+    /// Sets send actions to the store, rather than setting values directly.
     /// Optional `animation` parameter allows you to trigger an animation
     /// for binding sets.
     public func binding<Value>(
         get: @escaping (State) -> Value,
         tag: @escaping (Value) -> Action,
-        animation: Animation? = nil
+        animation: Animation?
     ) -> Binding<Value> {
         Binding(
             get: { get(self.state) },


### PR DESCRIPTION
Previously if no animation was passed to binding, we would send `withAnimation(nil)`. However, we don't want to set `withAnimation(nil)` unless explicitly asked, as this may override withAnimation called elsewhere.

Instead, we now introduce two forms of `Store.binding`:

```
Store.binding(get:tag:)
Store.binding(get:tag:animation:)
```

The first form does not call withAnimation, leaving the transaction state alone.