### PR TITLE
Introduce ViewStore for scoped component stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 A simple Elm-like Store for SwiftUI, based on [ObservableObject](https://developer.apple.com/documentation/combine/observableobject).
 
-ObservableStore helps you craft more reliable apps by centralizing all of your application state into one place, and making all changes to state deterministic. If you’ve ever used [Elm](https://guide.elm-lang.org/architecture/) or [Redux](https://redux.js.org/), you get the gist. All state updates happen through actions passed to an update function. This guarantees your application will produce exactly the same state, given the same actions in the same order.
+ObservableStore helps you craft more reliable apps by centralizing all of your application state into one place, and giving you a deterministic system for managing state changes and side-effects. All state updates happen through actions passed to an update function. This guarantees your application will produce exactly the same state, given the same actions in the same order. If you’ve ever used [Elm](https://guide.elm-lang.org/architecture/) or [Redux](https://redux.js.org/), you get the gist.
 
 Because `Store` is an [ObservableObject](https://developer.apple.com/documentation/combine/observableobject), it can be used anywhere in SwiftUI that ObservableObject would be used.
 
-Store is meant to be used as part of a single app-wide, or major-view-wide component. It deliberately does not solve for nested components or nested stores. Following Elm, deeply nested components are avoided. Instead, it is designed for apps that use a single store, or perhaps one store per major view. Instead of decomposing an app into many stateful components, ObservableStore favors decomposing an app into many stateless views that share the same store and actions. Sub-views can be passed data through bare properties of `store.state`, or bindings, which can be created with `store.binding`, or share the store globally, through [`EnvironmentObject`](https://developer.apple.com/documentation/swiftui/environmentobject). See <https://guide.elm-lang.org/architecture/> and <https://guide.elm-lang.org/webapps/structure.html> for more about this philosophy.
+Store can be used as a single shared [`EnvironmentObject`](https://developer.apple.com/documentation/swiftui/environmentobject), or you can pass scoped parts of store down to sub-view through:
+
+- Bare properties of `store.state`
+- Ordinary SwiftUI bindings
+- ViewStores that that provide a component-scoped store for an underlying parent store.
 
 ## Example
 
@@ -84,64 +88,6 @@ The `Update` returned is a small struct that contains a new state, plus any opti
 
 `state` can be any [`Equatable`](https://developer.apple.com/documentation/swift/equatable) type, typically a struct. Before setting a new state, Store checks that it is not equal to the previous state. New states that are equal to old states are not set, making them a no-op. This means views only recalculate when the state actually changes. Additionally, because state is Equatable, you can make any view that relies on Store, or part of Store, an [EquatableView](https://developer.apple.com/documentation/swiftui/equatableview), so the view’s body will only be recalculated if the values it cares about change.
 
-## Getting and setting state in views
-
-There are a few different ways to work with Store in views.
-
-`Store.state` lets you reference the current state directly within views. It’s read-only, so this is the approach to take if your view just needs to read, and doesn’t need to change state.
-
-```swift
-Text(store.state.text)
-```
-
-`Store.send(_)` lets you send actions to the store to change state. You might call send within a button action, or event callback, for example.
-
-```swift
-Button("Set color to red") {
-    store.send(AppAction.setColor(.red))
-}
-```
-
-`Store.binding(get:tag:)` lets you create a [binding](https://developer.apple.com/documentation/swiftui/binding) that represents some part of the state. A get function reads the state into a value, a tag function turns a value set on the binding into an action. The result is a binding that can be passed to any vanilla SwiftUI view, yet changes state only through deterministic updates.
-
-```swift
-TextField(
-    "Username"
-    text: store.binding(
-        get: { state in state.username },
-        tag: { username in .setUsername(username) }
-    )
-)
-```
-
-Or, shorthand:
-
-```swift
-TextField(
-    "Username"
-    text: store.binding(
-        get: \.username,
-        tag: .setUsername
-    )
-)
-```
-
-You can also create bindings for sub-properties, just like with any other SwiftUI binding. Here's an example of creating a binding to a deep property of the state:
-
-```swift
-TextField(
-    "Bio"
-    text: store
-        .binding(
-            get: { state in state.settings },
-            tag: { settings in .setSettings(settings) }
-        )
-        .profile
-        .bio
-)
-```
-
-Bottom line, because Store is just an ordinary [ObservableObject](https://developer.apple.com/documentation/combine/observableobject), and can produce bindings, you can write views exactly the same way you write vanilla SwiftUI views. No special magic! Properties, [@Binding](https://developer.apple.com/documentation/swiftui/binding), [@ObservedObject](https://developer.apple.com/documentation/swiftui/observedobject), [@StateObject](https://developer.apple.com/documentation/swiftui/stateobject) and [@EnvironmentObject](https://developer.apple.com/documentation/swiftui/environmentobject) all work as you would expect.
 
 ## Effects
 
@@ -207,4 +153,178 @@ func update(
 }
 ```
 
-When you specify a transition or animation as part of an Update thisway, Store will use it when setting the state for the update.
+When you specify a transition or animation as part of an Update, Store will use that animation when setting the state for the update.
+
+## Getting and setting state in views
+
+There are a few different ways to work with Store in views.
+
+`Store.state` lets you reference the current state directly within views. It’s read-only, so this is the approach to take if your view just needs to read, and doesn’t need to change state.
+
+```swift
+Text(store.state.text)
+```
+
+`Store.send(_)` lets you send actions to the store to change state. You might call send within a button action, or event callback, for example.
+
+```swift
+Button("Set color to red") {
+    store.send(AppAction.setColor(.red))
+}
+```
+
+## Bindings
+
+`Binding(store:get:tag:)` lets you create a [binding](https://developer.apple.com/documentation/swiftui/binding) that represents some part of the state. The `get` closure reads the state into a value, and the `tag` closure wraps the value set on the binding in an action. The result is a binding that can be passed to any vanilla SwiftUI view, but changes state only through deterministic updates.
+
+```swift
+TextField(
+    "Username"
+    text: Binding(
+        store: store,
+        get: { state in state.username },
+        tag: { username in .setUsername(username) }
+    )
+)
+```
+
+Or, shorthand:
+
+```swift
+TextField(
+    "Username"
+    text: Binding(
+        store: store,
+        get: \.username,
+        tag: .setUsername
+    )
+)
+```
+
+Bottom line, because Store is just an ordinary [ObservableObject](https://developer.apple.com/documentation/combine/observableobject), and can produce bindings, you can write views exactly the same way you write vanilla SwiftUI views. No special magic! Properties, [@Binding](https://developer.apple.com/documentation/swiftui/binding), [@ObservedObject](https://developer.apple.com/documentation/swiftui/observedobject), [@StateObject](https://developer.apple.com/documentation/swiftui/stateobject) and [@EnvironmentObject](https://developer.apple.com/documentation/swiftui/environmentobject) all work as you would expect.
+
+
+## ViewStore
+
+ViewStore lets you create component-scoped stores from a shared parent store. This allows you to create apps from free-standing deterministic components that all have their own local state, actions, and update functions, but share the same underlying root store. You can think of ViewStore as like a binding, except that it exposes the same StoreProtocol API that Store does.
+
+Imagine we have a stand-alone child component that looks something like this:
+
+```swift
+enum ChildAction {
+    case increment
+}
+
+struct ChildModel: Equatable {
+    var count: Int = 0
+
+    static func update(
+        state: ChildModel,
+        action: ChildAction,
+        environment: Void
+    ) -> Update<ChildModel, ChildAction> {
+        switch action {
+        case .increment:
+            var model = state
+            model.count = model.count + 1
+            return Update(state: model)
+        }
+    }
+}
+
+struct ChildView: View {
+    var store: ViewStore<ChildModel, ChildAction>
+
+    var body: some View {
+        VStack {
+            Text("Count \(store.state.count)")
+            Button(
+                "Increment",
+                action: {
+                    store.send(ChildAction.increment)
+                }
+            )
+        }
+    }
+}
+```
+
+Now we want to integrate this child component with other components that share the same root store. To create a ViewStore from the root store, we need to specify a way to map from this child component's state and actions to the root store state and actions. This is where `CursorProtocol` comes in. It defines three things:
+
+- A way to `get` a local state from the global state
+- A way to `set` a local state on a global state
+- A way to `tag` a local action so it becomes a global action
+
+```swift
+struct AppChildCursor: CursorProtocol {
+    /// Get child state from parent
+    static func get(state: ParentModel) -> ChildModel {
+        state.child
+    }
+
+    /// Set child state on parent
+    static func set(state: ParentModel, inner child: ChildModel) -> ParentModel {
+        var model = state
+        model.child = child
+        return model
+    }
+
+    /// Tag child action so it becomes a parent action
+    static func tag(_ action: ChildAction) -> ParentAction {
+        switch action {
+        default:
+            return .child(action)
+        }
+    }
+}
+```
+
+...This gives us everything we need to map from a local scope to the global store. Now we can create a scoped ViewStore from the shared app store and pass it down to our ChildView.
+
+```swift
+struct ContentView: View {
+    @ObservedObject private var store: Store<AppModel, AppAction, AppEnvironment>
+
+    var body: some View {
+        ChildView(
+            store: ViewStore(
+                store: store,
+                cursor: AppChildCursor.self
+            )
+        )
+    }
+}
+```
+
+ViewStores can also be created from other ViewStores, allowing for infinite hierarchical nesting of components.
+
+One more thing. Because cursors map or wrap child actions into parent actions, the parent update function must handle those actions. Cursors gives us a handy shortcut by synthesizing an `update` function that automatically maps child state and actions to parent state and actions.
+
+```swift
+enum AppAction {
+    case child(ChildAction)
+}
+
+struct AppModel: Equatable {
+    var child = ChildModel()
+
+    static func update(
+        state: AppModel,
+        action: AppAction,
+        environment: AppEnvironment
+    ) -> Update<AppModel, AppAction> {
+        switch {
+        case .child(action):
+            return AppChildCursor.update(
+                with: ChildModel.update,
+                state: state,
+                action: action,
+                environment: ()
+            )
+        }
+    }
+}```
+
+This tagging/update pattern gives parent components an opportunity to intercept and handle child actions in special ways.
+
+That's it! You can get state and send actions from the ViewStore, just like any other store, and it will translate local state changes and fx into app-level state changes and fx. Using ViewStore you can compose an app from multiple stand-alone components that each describe their own domain model and update logic.

--- a/README.md
+++ b/README.md
@@ -323,7 +323,8 @@ struct AppModel: Equatable {
             )
         }
     }
-}```
+}
+```
 
 This tagging/update pattern gives parent components an opportunity to intercept and handle child actions in special ways.
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ struct AppModel: ModelProtocol {
         environment: AppEnvironment
     ) -> Update<AppModel> {
         switch {
-        case .child(action):
+        case .child(let action):
             return AppChildCursor.update(
                 state: state,
                 action: action,

--- a/README.md
+++ b/README.md
@@ -109,11 +109,9 @@ The `Update` returned is a small struct that contains a new state, plus any opti
 
 ## Effects
 
- Updates are also able to produce asynchronous effects via [Combine](https://developer.apple.com/documentation/combine) publishers. This lets you schedule asynchronous things like HTTP requests or database calls in response to actions. Using effects, you can model everything via a deterministic sequence of actions, even asynchronous side-effects.
+ Updates are also able to produce asynchronous effects via [Combine](https://developer.apple.com/documentation/combine) publishers. This gives you a deterministic way to schedule sync and async side-effects like HTTP requests or database calls in response to actions.
  
-Effects are modeled as [Combine Publishers](https://developer.apple.com/documentation/combine/publishers) which publish actions and never fail.
-
-For convenience, ObservableStore defines a typealias for effect publishers:
+Effects are modeled as [Combine Publishers](https://developer.apple.com/documentation/combine/publishers) which publish actions and never fail. For convenience, ObservableStore defines a typealias for effect publishers:
 
 ```swift
 public typealias Fx<Action> = AnyPublisher<Action, Never>

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -10,15 +10,28 @@ import SwiftUI
 /// Fx is a publisher that publishes actions and never fails.
 public typealias Fx<Action> = AnyPublisher<Action, Never>
 
-/// Update represents a `State` change, together with an `Fx` publisher,
+/// A model is an equatable type that knows how to create
+/// state `Updates` for itself via a static update function.
+public protocol ModelProtocol: Equatable {
+    associatedtype Action
+    associatedtype Environment
+
+    static func update(
+        state: Self,
+        action: Action,
+        environment: Environment
+    ) -> Update<Self>
+}
+
+/// Update represents a state change, together with an `Fx` publisher,
 /// and an optional `Transaction`.
-public struct Update<State, Action>
-where State: Equatable {
+public struct Update<Model>
+where Model: ModelProtocol {
     /// `State` for this update
-    public var state: State
+    public var state: Model
     /// `Fx` for this update.
     /// Default is an `Empty` publisher (no effects)
-    public var fx: Fx<Action>
+    public var fx: Fx<Model.Action>
     /// The transaction that should be set during this update.
     /// Store uses this value to set the transaction while updating state,
     /// allowing you to drive explicit animations from your update function.
@@ -28,8 +41,8 @@ where State: Equatable {
     public var transaction: Transaction?
 
     public init(
-        state: State,
-        fx: Fx<Action> = Empty(completeImmediately: true)
+        state: Model,
+        fx: Fx<Model.Action> = Empty(completeImmediately: true)
             .eraseToAnyPublisher(),
         transaction: Transaction? = nil
     ) {
@@ -40,7 +53,7 @@ where State: Equatable {
 
     /// Merge existing fx together with new fx.
     /// - Returns a new `Update`
-    public func mergeFx(_ fx: Fx<Action>) -> Update<State, Action> {
+    public func mergeFx(_ fx: Fx<Model.Action>) -> Update<Model> {
         var this = self
         this.fx = self.fx.merge(with: fx).eraseToAnyPublisher()
         return this
@@ -65,7 +78,7 @@ where State: Equatable {
     ///
     /// - Returns a new `Update`
     public func pipe(
-        _ through: (State) -> Self
+        _ through: (Model) -> Self
     ) -> Self {
         let next = through(self.state)
         let fx = self.fx.merge(with: next.fx).eraseToAnyPublisher()
@@ -82,12 +95,11 @@ where State: Equatable {
 /// - `send` actions
 /// Stores are equatable, meaning you can also use them with `EquatableView`.
 public protocol StoreProtocol: Equatable {
-    associatedtype State: Equatable
-    associatedtype Action
+    associatedtype Model: ModelProtocol
 
-    var state: State { get }
+    var state: Model { get }
 
-    func send(_ action: Action) -> Void
+    func send(_ action: Model.Action) -> Void
 }
 
 extension StoreProtocol {
@@ -107,19 +119,14 @@ extension StoreProtocol {
 /// Store has a `@Published` `state` (typically a struct).
 /// All updates and effects to this state happen through actions
 /// sent to `store.send`.
-public final class Store<State, Action, Environment>: ObservableObject, StoreProtocol
-where State: Equatable {
+public final class Store<Model>: ObservableObject, StoreProtocol
+where Model: ModelProtocol
+{
     /// Stores cancellables by ID
     private(set) var cancellables: [UUID: AnyCancellable] = [:]
     /// Current state.
     /// All writes to state happen through actions sent to `Store.send`.
-    @Published public private(set) var state: State
-    /// Update function for state
-    public var update: (
-        State,
-        Action,
-        Environment
-    ) -> Update<State, Action>
+    @Published public private(set) var state: Model
     /// Environment, which typically holds references to outside information,
     /// such as API methods.
     ///
@@ -134,18 +141,12 @@ where State: Equatable {
     /// Store will hold on to the resulting `fx` publisher until it completes,
     /// which in the case of long-lived services, could be until the
     /// app is stopped.
-    public var environment: Environment
+    public var environment: Model.Environment
 
     public init(
-        update: @escaping (
-            State,
-            Action,
-            Environment
-        ) -> Update<State, Action>,
-        state: State,
-        environment: Environment
+        state: Model,
+        environment: Model.Environment
     ) {
-        self.update = update
         self.state = state
         self.environment = environment
     }
@@ -155,7 +156,7 @@ where State: Equatable {
     ///
     /// Holds on to the cancellable until publisher completes.
     /// When publisher completes, removes cancellable.
-    public func subscribe(to fx: Fx<Action>) {
+    public func subscribe(to fx: Fx<Model.Action>) {
         // Create a UUID for the cancellable.
         // Store cancellable in dictionary by UUID.
         // Remove cancellable from dictionary upon effect completion.
@@ -194,9 +195,13 @@ where State: Equatable {
     /// However it also means that publishers which run off-main-thread MUST
     /// make sure that they join the main thread (e.g. with
     /// `.receive(on: DispatchQueue.main)`).
-    public func send(_ action: Action) {
+    public func send(_ action: Model.Action) {
         // Generate next state and effect
-        let next = update(self.state, action, self.environment)
+        let next = Model.update(
+            state: self.state,
+            action: action,
+            environment: self.environment
+        )
         // Set `state` if changed.
         //
         // Mutating state (a `@Published` property) will fire `objectWillChange`
@@ -224,32 +229,21 @@ where State: Equatable {
     }
 }
 
-/// LensProtocol defines a way to get and set inner values in an outer
-/// data container.
-public protocol LensProtocol {
-    associatedtype OuterState
-    associatedtype InnerState
+/// A cursor provides a complete description of how to map from one component
+/// domain to another.
+public protocol CursorProtocol {
+    associatedtype Model: ModelProtocol
+    associatedtype ViewModel: ModelProtocol
 
     /// Get an inner state from an outer state
-    static func get(state: OuterState) -> InnerState
+    static func get(state: Model) -> ViewModel
 
     /// Set an inner state on an outer state, returning an outer state
-    static func set(state: OuterState, inner: InnerState) -> OuterState
-}
-
-/// TaggableActionProtocol defines a way to box an action for passing
-/// between domains.
-public protocol TaggableActionProtocol {
-    associatedtype OuterAction
-    associatedtype InnerAction
+    static func set(state: Model, inner: ViewModel) -> Model
 
     /// Tag an inner action, transforming it into an outer action
-    static func tag(_ action: InnerAction) -> OuterAction
+    static func tag(_ action: ViewModel.Action) -> Model.Action
 }
-
-/// A cursor combines a lens and a taggable action to provide a complete
-/// description of how to map from one component domain to another.
-public protocol CursorProtocol: LensProtocol, TaggableActionProtocol {}
 
 extension CursorProtocol {
     /// Update an outer state through a cursor.
@@ -262,17 +256,16 @@ extension CursorProtocol {
     /// - `action` the inner action
     /// - `environment` the environment for the update function
     /// - Returns a new outer state
-    public static func update<Environment>(
-        with update: (
-            InnerState,
-            InnerAction,
-            Environment
-        ) -> Update<InnerState, InnerAction>,
-        state: OuterState,
-        action innerAction: InnerAction,
-        environment: Environment
-    ) -> Update<OuterState, OuterAction> {
-        let next = update(get(state: state), innerAction, environment)
+    public static func update(
+        state: Model,
+        action viewAction: ViewModel.Action,
+        environment: ViewModel.Environment
+    ) -> Update<Model> {
+        let next = ViewModel.update(
+            state: get(state: state),
+            action: viewAction,
+            environment: environment
+        )
         return Update(
             state: set(state: state, inner: next.state),
             fx: next.fx.map(tag).eraseToAnyPublisher(),
@@ -293,46 +286,31 @@ extension CursorProtocol {
 //  I suspect this has something to do with either the guts of SwiftUI or the
 //  guts of UIViewRepresentable.
 //  2022-06-12 Gordon Brander
-public struct ViewStore<State, Action>: StoreProtocol, Equatable
-where State: Equatable
+public struct ViewStore<ViewModel>: StoreProtocol
+where ViewModel: ModelProtocol
 {
-    private let _get: () -> State
-    private let _send: (Action) -> Void
+    private let _get: () -> ViewModel
+    private let _send: (ViewModel.Action) -> Void
 
     /// Initialize a ViewStore using a get and send closure.
     public init(
-        get: @escaping () -> State,
-        send: @escaping (Action) -> Void
+        get: @escaping () -> ViewModel,
+        send: @escaping (ViewModel.Action) -> Void
     ) {
         self._get = get
         self._send = send
     }
 
     /// Get current state
-    public var state: State { self._get() }
+    public var state: ViewModel { self._get() }
 
     /// Send an action
-    public func send(_ action: Action) {
+    public func send(_ action: ViewModel.Action) {
         self._send(action)
     }
 }
 
 extension ViewStore {
-    /// Initialize a ViewStore from a store of some type, and a get and tag
-    /// function.
-    /// - Store can be any type conforming to `StoreProtocol`
-    /// - `get` and `tag` can be any closure.
-    public init<Store: StoreProtocol>(
-        store: Store,
-        get: @escaping (Store.State) -> State,
-        tag: @escaping (Action) -> Store.Action
-    ) {
-        self.init(
-            get: { get(store.state) },
-            send: { action in store.send(tag(action)) }
-        )
-    }
-
     /// Initialize a ViewStore from a store of some type, and a cursor.
     /// - Store can be any type conforming to `StoreProtocol`
     /// - Cursor can be any type conforming to `CursorProtocol`
@@ -340,10 +318,8 @@ extension ViewStore {
     where
         Store: StoreProtocol,
         Cursor: CursorProtocol,
-        Store.State == Cursor.OuterState,
-        Store.Action == Cursor.OuterAction,
-        State == Cursor.InnerState,
-        Action == Cursor.InnerAction
+        Store.Model == Cursor.Model,
+        ViewModel == Cursor.ViewModel
     {
         self.init(
             get: { Cursor.get(state: store.state) },
@@ -356,9 +332,9 @@ extension ViewStore {
     /// Create a ViewStore for a constant state that swallows actions.
     /// Convenience for view previews.
     public static func constant(
-        state: State
-    ) -> ViewStore<State, Action> {
-        ViewStore<State, Action>(
+        state: ViewModel
+    ) -> ViewStore<ViewModel> {
+        ViewStore<ViewModel>(
             get: { state },
             send: { action in }
         )
@@ -372,8 +348,8 @@ extension Binding {
     /// - Returns a binding suitable for use in a vanilla SwiftUI view.
     public init<Store: StoreProtocol>(
         store: Store,
-        get: @escaping (Store.State) -> Value,
-        tag: @escaping (Value) -> Store.Action
+        get: @escaping (Store.Model) -> Value,
+        tag: @escaping (Value) -> Store.Model.Action
     ) {
         self.init(
             get: { get(store.state) },

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -90,8 +90,8 @@ public struct Update<Model: ModelProtocol> {
 }
 
 /// A store is any type that can
-/// - get an equatable `state`
-/// - `send` actions
+/// - get a state
+/// - send actions
 public protocol StoreProtocol {
     associatedtype Model: ModelProtocol
 

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -77,6 +77,28 @@ where State: Equatable {
     }
 }
 
+/// A store is any type that can
+/// - get an equatable `state`
+/// - `send` actions
+/// Stores are equatable, meaning you can also use them with `EquatableView`.
+public protocol StoreProtocol: Equatable {
+    associatedtype State: Equatable
+    associatedtype Action
+
+    var state: State { get }
+
+    func send(_ action: Action) -> Void
+}
+
+extension StoreProtocol {
+    public static func == (
+        lhs: Self,
+        rhs: Self
+    ) -> Bool {
+        lhs.state == rhs.state
+    }
+}
+
 /// Store is a source of truth for a state.
 ///
 /// Store is an `ObservableObject`. You can use it in a view via
@@ -85,24 +107,7 @@ where State: Equatable {
 /// Store has a `@Published` `state` (typically a struct).
 /// All updates and effects to this state happen through actions
 /// sent to `store.send`.
-///
-/// Store is meant to be used as part of a single app-wide, or
-/// major-view-wide component. Store deliberately does not solve for nested
-/// components or nested stores. Following Elm, deeply nested components
-/// are avoided. Instead, an app should use a single store, or perhaps one
-/// store per major view. Components should not have to communicate with
-/// each other. If nested components do have to communicate, it is
-/// probably a sign they should be the same component with a shared store.
-///
-/// Instead of decomposing an app into components, we decompose the app into
-/// views that share the same store and actions. Sub-views should be either
-/// stateless, consuming bare properties of `store.state`, or take bindings,
-/// which can be created with `store.binding`.
-///
-/// See https://guide.elm-lang.org/architecture/
-/// and https://guide.elm-lang.org/webapps/structure.html
-/// for more about this approach.
-public final class Store<State, Action, Environment>: ObservableObject
+public final class Store<State, Action, Environment>: ObservableObject, StoreProtocol
 where State: Equatable {
     /// Stores cancellables by ID
     private(set) var cancellables: [UUID: AnyCancellable] = [:]
@@ -143,39 +148,6 @@ where State: Equatable {
         self.update = update
         self.state = state
         self.environment = environment
-    }
-
-    /// Create a binding that can update the store.
-    /// Sets send actions to the store, rather than setting values directly.
-    public func binding<Value>(
-        get: @escaping (State) -> Value,
-        tag: @escaping (Value) -> Action
-    ) -> Binding<Value> {
-        Binding(
-            get: { get(self.state) },
-            set: { value in
-                self.send(tag(value))
-            }
-        )
-    }
-
-    /// Create a binding that can update the store.
-    /// Sets send actions to the store, rather than setting values directly.
-    /// Optional `animation` parameter allows you to trigger an animation
-    /// for binding sets.
-    public func binding<Value>(
-        get: @escaping (State) -> Value,
-        tag: @escaping (Value) -> Action,
-        animation: Animation?
-    ) -> Binding<Value> {
-        Binding(
-            get: { get(self.state) },
-            set: { value in
-                withAnimation(animation) {
-                    self.send(tag(value))
-                }
-            }
-        )
     }
 
     /// Subscribe to a publisher of actions, piping them through to
@@ -249,5 +221,163 @@ where State: Equatable {
         }
         // Run effect
         self.subscribe(to: next.fx)
+    }
+}
+
+/// LensProtocol defines a way to get and set inner values in an outer
+/// data container.
+public protocol LensProtocol {
+    associatedtype OuterState
+    associatedtype InnerState
+
+    /// Get an inner state from an outer state
+    static func get(state: OuterState) -> InnerState
+
+    /// Set an inner state on an outer state, returning an outer state
+    static func set(state: OuterState, inner: InnerState) -> OuterState
+}
+
+/// TaggableActionProtocol defines a way to box an action for passing
+/// between domains.
+public protocol TaggableActionProtocol {
+    associatedtype OuterAction
+    associatedtype InnerAction
+
+    /// Tag an inner action, transforming it into an outer action
+    static func tag(_ action: InnerAction) -> OuterAction
+}
+
+/// A cursor combines a lens and a taggable action to provide a complete
+/// description of how to map from one component domain to another.
+public protocol CursorProtocol: LensProtocol, TaggableActionProtocol {}
+
+extension CursorProtocol {
+    /// Update an outer state through a cursor.
+    /// CursorProtocol.update offers a convenient way to call child
+    /// update functions from the parent domain, and get parent-domain
+    /// states and actions back from it.
+    ///
+    /// - `with` the inner update function to use
+    /// - `state` the outer state
+    /// - `action` the inner action
+    /// - `environment` the environment for the update function
+    /// - Returns a new outer state
+    public static func update<Environment>(
+        with update: (
+            InnerState,
+            InnerAction,
+            Environment
+        ) -> Update<InnerState, InnerAction>,
+        state: OuterState,
+        action innerAction: InnerAction,
+        environment: Environment
+    ) -> Update<OuterState, OuterAction> {
+        let next = update(get(state: state), innerAction, environment)
+        return Update(
+            state: set(state: state, inner: next.state),
+            fx: next.fx.map(tag).eraseToAnyPublisher(),
+            transaction: next.transaction
+        )
+    }
+}
+
+/// ViewStore is a local projection of a Store that can be passed down to
+/// a child view.
+//  NOTE: ViewStore works like Binding. It reads state at runtime using a
+//  getter closure that you provide. It is important that we
+//  read the state via a closure, like Binding does, rather than
+//  storing the literal value as a property of the instance.
+//  If you store the literal value as a property, you will have "liveness"
+//  issues with the data in views, especially around things like text editors.
+//  Letters entered out of order, old states showing up, etc.
+//  I suspect this has something to do with either the guts of SwiftUI or the
+//  guts of UIViewRepresentable.
+//  2022-06-12 Gordon Brander
+public struct ViewStore<State, Action>: StoreProtocol, Equatable
+where State: Equatable
+{
+    private let _get: () -> State
+    private let _send: (Action) -> Void
+
+    /// Initialize a ViewStore using a get and send closure.
+    public init(
+        get: @escaping () -> State,
+        send: @escaping (Action) -> Void
+    ) {
+        self._get = get
+        self._send = send
+    }
+
+    /// Get current state
+    public var state: State { self._get() }
+
+    /// Send an action
+    public func send(_ action: Action) {
+        self._send(action)
+    }
+}
+
+extension ViewStore {
+    /// Initialize a ViewStore from a store of some type, and a get and tag
+    /// function.
+    /// - Store can be any type conforming to `StoreProtocol`
+    /// - `get` and `tag` can be any closure.
+    public init<Store: StoreProtocol>(
+        store: Store,
+        get: @escaping (Store.State) -> State,
+        tag: @escaping (Action) -> Store.Action
+    ) {
+        self.init(
+            get: { get(store.state) },
+            send: { action in store.send(tag(action)) }
+        )
+    }
+
+    /// Initialize a ViewStore from a store of some type, and a cursor.
+    /// - Store can be any type conforming to `StoreProtocol`
+    /// - Cursor can be any type conforming to `CursorProtocol`
+    public init<Store, Cursor>(store: Store, cursor: Cursor.Type)
+    where
+        Store: StoreProtocol,
+        Cursor: CursorProtocol,
+        Store.State == Cursor.OuterState,
+        Store.Action == Cursor.OuterAction,
+        State == Cursor.InnerState,
+        Action == Cursor.InnerAction
+    {
+        self.init(
+            get: { Cursor.get(state: store.state) },
+            send: { action in store.send(Cursor.tag(action)) }
+        )
+    }
+}
+
+extension ViewStore {
+    /// Create a ViewStore for a constant state that swallows actions.
+    /// Convenience for view previews.
+    public static func constant(
+        state: State
+    ) -> ViewStore<State, Action> {
+        ViewStore<State, Action>(
+            get: { state },
+            send: { action in }
+        )
+    }
+}
+
+extension Binding {
+    /// Initialize a Binding from a store.
+    /// - `get` reads the store state to a binding value.
+    /// - `tag` transforms the value into an action.
+    /// - Returns a binding suitable for use in a vanilla SwiftUI view.
+    public init<Store: StoreProtocol>(
+        store: Store,
+        get: @escaping (Store.State) -> Value,
+        tag: @escaping (Value) -> Store.Action
+    ) {
+        self.init(
+            get: { get(store.state) },
+            set: { value in store.send(tag(value)) }
+        )
     }
 }

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -25,8 +25,7 @@ public protocol ModelProtocol: Equatable {
 
 /// Update represents a state change, together with an `Fx` publisher,
 /// and an optional `Transaction`.
-public struct Update<Model>
-where Model: ModelProtocol {
+public struct Update<Model: ModelProtocol> {
     /// `State` for this update
     public var state: Model
     /// `Fx` for this update.
@@ -275,9 +274,7 @@ extension CursorProtocol {
 //  I suspect this has something to do with either the guts of SwiftUI or the
 //  guts of UIViewRepresentable.
 //  2022-06-12 Gordon Brander
-public struct ViewStore<ViewModel>: StoreProtocol
-where ViewModel: ModelProtocol
-{
+public struct ViewStore<ViewModel: ModelProtocol>: StoreProtocol {
     private let _get: () -> ViewModel
     private let _send: (ViewModel.Action) -> Void
 

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -93,22 +93,12 @@ where Model: ModelProtocol {
 /// A store is any type that can
 /// - get an equatable `state`
 /// - `send` actions
-/// Stores are equatable, meaning you can also use them with `EquatableView`.
-public protocol StoreProtocol: Equatable {
+public protocol StoreProtocol {
     associatedtype Model: ModelProtocol
 
     var state: Model { get }
 
     func send(_ action: Model.Action) -> Void
-}
-
-extension StoreProtocol {
-    public static func == (
-        lhs: Self,
-        rhs: Self
-    ) -> Bool {
-        lhs.state == rhs.state
-    }
 }
 
 /// Store is a source of truth for a state.

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -90,8 +90,8 @@ public protocol StoreProtocol: Equatable {
     func send(_ action: Action) -> Void
 }
 
-extension StoreProtocol {
-    public static func == (
+public extension StoreProtocol {
+    static func == (
         lhs: Self,
         rhs: Self
     ) -> Bool {
@@ -251,7 +251,7 @@ public protocol TaggableActionProtocol {
 /// description of how to map from one component domain to another.
 public protocol CursorProtocol: LensProtocol, TaggableActionProtocol {}
 
-extension CursorProtocol {
+public extension CursorProtocol {
     /// Update an outer state through a cursor.
     /// CursorProtocol.update offers a convenient way to call child
     /// update functions from the parent domain, and get parent-domain
@@ -262,7 +262,7 @@ extension CursorProtocol {
     /// - `action` the inner action
     /// - `environment` the environment for the update function
     /// - Returns a new outer state
-    public static func update<Environment>(
+    static func update<Environment>(
         with update: (
             InnerState,
             InnerAction,
@@ -293,7 +293,7 @@ extension CursorProtocol {
 //  I suspect this has something to do with either the guts of SwiftUI or the
 //  guts of UIViewRepresentable.
 //  2022-06-12 Gordon Brander
-public struct ViewStore<State, Action>: StoreProtocol, Equatable
+public struct ViewStore<State, Action>: StoreProtocol
 where State: Equatable
 {
     private let _get: () -> State
@@ -317,26 +317,11 @@ where State: Equatable
     }
 }
 
-extension ViewStore {
-    /// Initialize a ViewStore from a store of some type, and a get and tag
-    /// function.
-    /// - Store can be any type conforming to `StoreProtocol`
-    /// - `get` and `tag` can be any closure.
-    public init<Store: StoreProtocol>(
-        store: Store,
-        get: @escaping (Store.State) -> State,
-        tag: @escaping (Action) -> Store.Action
-    ) {
-        self.init(
-            get: { get(store.state) },
-            send: { action in store.send(tag(action)) }
-        )
-    }
-
+public extension ViewStore {
     /// Initialize a ViewStore from a store of some type, and a cursor.
     /// - Store can be any type conforming to `StoreProtocol`
     /// - Cursor can be any type conforming to `CursorProtocol`
-    public init<Store, Cursor>(store: Store, cursor: Cursor.Type)
+    init<Store, Cursor>(store: Store, cursor: Cursor.Type)
     where
         Store: StoreProtocol,
         Cursor: CursorProtocol,
@@ -352,10 +337,10 @@ extension ViewStore {
     }
 }
 
-extension ViewStore {
+public extension ViewStore {
     /// Create a ViewStore for a constant state that swallows actions.
     /// Convenience for view previews.
-    public static func constant(
+    static func constant(
         state: State
     ) -> ViewStore<State, Action> {
         ViewStore<State, Action>(
@@ -365,12 +350,12 @@ extension ViewStore {
     }
 }
 
-extension Binding {
+public extension Binding {
     /// Initialize a Binding from a store.
     /// - `get` reads the store state to a binding value.
     /// - `tag` transforms the value into an action.
     /// - Returns a binding suitable for use in a vanilla SwiftUI view.
-    public init<Store: StoreProtocol>(
+    init<Store: StoreProtocol>(
         store: Store,
         get: @escaping (Store.State) -> Value,
         tag: @escaping (Value) -> Store.Action

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -12,8 +12,7 @@ public typealias Fx<Action> = AnyPublisher<Action, Never>
 
 /// Update represents a `State` change, together with an `Fx` publisher,
 /// and an optional `Transaction`.
-public struct Update<State, Action>
-where State: Equatable {
+public struct Update<State, Action> {
     /// `State` for this update
     public var state: State
     /// `Fx` for this update.
@@ -81,22 +80,13 @@ where State: Equatable {
 /// - get an equatable `state`
 /// - `send` actions
 /// Stores are equatable, meaning you can also use them with `EquatableView`.
-public protocol StoreProtocol: Equatable {
-    associatedtype State: Equatable
+public protocol StoreProtocol {
+    associatedtype State
     associatedtype Action
 
     var state: State { get }
 
     func send(_ action: Action) -> Void
-}
-
-public extension StoreProtocol {
-    static func == (
-        lhs: Self,
-        rhs: Self
-    ) -> Bool {
-        lhs.state == rhs.state
-    }
 }
 
 /// Store is a source of truth for a state.
@@ -107,8 +97,18 @@ public extension StoreProtocol {
 /// Store has a `@Published` `state` (typically a struct).
 /// All updates and effects to this state happen through actions
 /// sent to `store.send`.
-public final class Store<State, Action, Environment>: ObservableObject, StoreProtocol
-where State: Equatable {
+public final class Store<State, Action, Environment>:
+    ObservableObject, StoreProtocol, Equatable
+where
+    State: Equatable
+{
+    public static func == (
+        lhs: Store<State, Action, Environment>,
+        rhs: Store<State, Action, Environment>
+    ) -> Bool {
+        lhs.state == rhs.state
+    }
+
     /// Stores cancellables by ID
     private(set) var cancellables: [UUID: AnyCancellable] = [:]
     /// Current state.
@@ -293,9 +293,16 @@ public extension CursorProtocol {
 //  I suspect this has something to do with either the guts of SwiftUI or the
 //  guts of UIViewRepresentable.
 //  2022-06-12 Gordon Brander
-public struct ViewStore<State, Action>: StoreProtocol
+public struct ViewStore<State, Action>: StoreProtocol, Equatable
 where State: Equatable
 {
+    public static func == (
+        lhs: ViewStore<State, Action>,
+        rhs: ViewStore<State, Action>
+    ) -> Bool {
+        lhs.state == rhs.state
+    }
+
     private let _get: () -> State
     private let _send: (Action) -> Void
 

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Combine
+import SwiftUI
 @testable import ObservableStore
 
 final class ObservableStoreTests: XCTestCase {
@@ -89,7 +90,8 @@ final class ObservableStoreTests: XCTestCase {
             state: AppState(),
             environment: AppState.Environment()
         )
-        let binding = store.binding(
+        let binding = Binding(
+            store: store,
             get: \.count,
             tag: AppState.Action.setCount
         )
@@ -103,7 +105,8 @@ final class ObservableStoreTests: XCTestCase {
             state: AppState(),
             environment: AppState.Environment()
         )
-        let binding = store.binding(
+        let binding = Binding(
+            store: store,
             get: \.editor,
             tag: AppState.Action.setEditor
         )

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 final class ObservableStoreTests: XCTestCase {
     /// App state
-    struct AppState: Equatable {
+    struct AppModel: ModelProtocol {
         enum Action {
             case increment
             case delayIncrement(Double)
@@ -29,10 +29,10 @@ final class ObservableStoreTests: XCTestCase {
 
         /// State update function
         static func update(
-            state: Self,
+            state: AppModel,
             action: Action,
             environment: Environment
-        ) -> Update<Self, Action> {
+        ) -> Update<AppModel> {
             switch action {
             case .increment:
                 var model = state
@@ -75,9 +75,8 @@ final class ObservableStoreTests: XCTestCase {
 
     func testStateAdvance() throws {
         let store = Store(
-            update: AppState.update,
-            state: AppState(),
-            environment: AppState.Environment()
+            state: AppModel(),
+            environment: AppModel.Environment()
         )
 
         store.send(.increment)
@@ -86,14 +85,13 @@ final class ObservableStoreTests: XCTestCase {
 
     func testBinding() throws {
         let store = Store(
-            update: AppState.update,
-            state: AppState(),
-            environment: AppState.Environment()
+            state: AppModel(),
+            environment: AppModel.Environment()
         )
         let binding = Binding(
             store: store,
             get: \.count,
-            tag: AppState.Action.setCount
+            tag: AppModel.Action.setCount
         )
         binding.wrappedValue = 2
         XCTAssertEqual(store.state.count, 2, "binding sends action")
@@ -101,14 +99,13 @@ final class ObservableStoreTests: XCTestCase {
 
     func testDeepBinding() throws {
         let store = Store(
-            update: AppState.update,
-            state: AppState(),
-            environment: AppState.Environment()
+            state: AppModel(),
+            environment: AppModel.Environment()
         )
         let binding = Binding(
             store: store,
             get: \.editor,
-            tag: AppState.Action.setEditor
+            tag: AppModel.Action.setEditor
         )
         .input
         .text
@@ -122,9 +119,8 @@ final class ObservableStoreTests: XCTestCase {
 
     func testEmptyFxRemovedOnComplete() {
         let store = Store(
-            update: AppState.update,
-            state: AppState(),
-            environment: AppState.Environment()
+            state: AppModel(),
+            environment: AppModel.Environment()
         )
         store.send(.increment)
         store.send(.increment)
@@ -145,9 +141,8 @@ final class ObservableStoreTests: XCTestCase {
 
     func testAsyncFxRemovedOnComplete() {
         let store = Store(
-            update: AppState.update,
-            state: AppState(),
-            environment: AppState.Environment()
+            state: AppModel(),
+            environment: AppModel.Environment()
         )
         store.send(.delayIncrement(0.1))
         store.send(.delayIncrement(0.2))
@@ -167,9 +162,8 @@ final class ObservableStoreTests: XCTestCase {
 
     func testStateOnlySetWhenNotEqual() {
         let store = Store(
-            update: AppState.update,
-            state: AppState(),
-            environment: AppState.Environment()
+            state: AppModel(),
+            environment: AppModel.Environment()
         )
 
         let expectation = XCTestExpectation(
@@ -202,7 +196,7 @@ final class ObservableStoreTests: XCTestCase {
     }
 
     /// Definition for app to test updates
-    struct TestUpdateMergeFxState: Equatable {
+    struct TestUpdateMergeFxState: ModelProtocol {
         enum Action {
             case setTitleAndSubtitleViaMergeFx(
                 title: String,
@@ -219,7 +213,7 @@ final class ObservableStoreTests: XCTestCase {
             state: Self,
             action: Action,
             environment: Environment
-        ) -> Update<Self, Action> {
+        ) -> Update<Self> {
             switch action {
             case .setTitle(let title):
                 var model = state
@@ -248,7 +242,6 @@ final class ObservableStoreTests: XCTestCase {
     
     func testUpdateMergeFx() {
         let store = Store(
-            update: TestUpdateMergeFxState.update,
             state: TestUpdateMergeFxState(),
             environment: TestUpdateMergeFxState.Environment()
         )

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -66,6 +66,14 @@ final class ObservableStoreTests: XCTestCase {
         var editor = Editor()
     }
 
+    struct SimpleCountView: View {
+        @Binding var count: Int
+
+        var body: some View {
+            Text("Count: \(count)")
+        }
+    }
+
     var cancellables = Set<AnyCancellable>()
 
     override func setUp() {
@@ -88,13 +96,16 @@ final class ObservableStoreTests: XCTestCase {
             state: AppModel(),
             environment: AppModel.Environment()
         )
-        let binding = Binding(
-            store: store,
-            get: \.count,
-            tag: AppModel.Action.setCount
+        let view = SimpleCountView(
+            count: Binding(
+                store: store,
+                get: \.count,
+                tag: AppModel.Action.setCount
+            )
         )
-        binding.wrappedValue = 2
-        XCTAssertEqual(store.state.count, 2, "binding sends action")
+        view.count = 2
+        XCTAssertEqual(view.count, 2, "binding is set")
+        XCTAssertEqual(store.state.count, 2, "binding sends action to store")
     }
 
     func testDeepBinding() throws {

--- a/Tests/ObservableStoreTests/ViewStoreTests.swift
+++ b/Tests/ObservableStoreTests/ViewStoreTests.swift
@@ -16,7 +16,7 @@ class TestsViewStore: XCTestCase {
         case setText(String)
     }
 
-    struct ParentModel: Equatable {
+    struct ParentModel: ModelProtocol {
         var child = ChildModel(text: "")
         var edits: Int = 0
 
@@ -24,24 +24,44 @@ class TestsViewStore: XCTestCase {
             state: ParentModel,
             action: ParentAction,
             environment: Void
-        ) -> Update<ParentModel, ParentAction> {
+        ) -> Update<ParentModel> {
             switch action {
             case .child(let action):
                 return ParentChildCursor.update(
-                    with: ChildModel.update,
                     state: state,
                     action: action,
                     environment: ()
                 )
             case .setText(let text):
                 var next = ParentChildCursor.update(
-                    with: ChildModel.update,
                     state: state,
                     action: .setText(text),
                     environment: ()
                 )
                 next.state.edits = next.state.edits + 1
                 return next
+            }
+        }
+    }
+
+    enum ChildAction: Hashable {
+        case setText(String)
+    }
+
+    struct ChildModel: ModelProtocol {
+        var text: String
+
+        static func update(
+            state: ChildModel,
+            action: ChildAction,
+            environment: Void
+        ) -> Update<ChildModel> {
+            switch action {
+            case .setText(let string):
+                var model = state
+                model.text = string
+                return Update(state: model)
+                    .animation(.default)
             }
         }
     }
@@ -65,28 +85,6 @@ class TestsViewStore: XCTestCase {
         }
     }
 
-    struct ChildModel: Hashable {
-        var text: String
-
-        static func update(
-            state: ChildModel,
-            action: ChildAction,
-            environment: Void
-        ) -> Update<ChildModel, ChildAction> {
-            switch action {
-            case .setText(let string):
-                var model = state
-                model.text = string
-                return Update(state: model)
-                    .animation(.default)
-            }
-        }
-    }
-
-    enum ChildAction: Hashable {
-        case setText(String)
-    }
-
     struct SimpleView: View {
         @Binding var text: String
 
@@ -97,12 +95,11 @@ class TestsViewStore: XCTestCase {
 
     func testViewStoreCursor() throws {
         let store = Store(
-            update: ParentModel.update,
             state: ParentModel(),
             environment: ()
         )
 
-        let viewStore: ViewStore<ChildModel, ChildAction> = ViewStore(
+        let viewStore: ViewStore<ChildModel> = ViewStore(
             store: store,
             cursor: ParentChildCursor.self
         )
@@ -125,15 +122,13 @@ class TestsViewStore: XCTestCase {
 
     func testViewStoreGetTag() throws {
         let store = Store(
-            update: ParentModel.update,
             state: ParentModel(),
             environment: ()
         )
 
-        let viewStore: ViewStore<ChildModel, ChildAction> = ViewStore(
+        let viewStore: ViewStore<ChildModel> = ViewStore(
             store: store,
-            get: { state in state.child },
-            tag: ParentChildCursor.tag
+            cursor: ParentChildCursor.self
         )
 
         viewStore.send(.setText("Foo"))
@@ -155,7 +150,6 @@ class TestsViewStore: XCTestCase {
     /// Test creating binding from a root Store
     func testStoreBinding() throws {
         let store = Store(
-            update: ParentModel.update,
             state: ParentModel(),
             environment: ()
         )
@@ -184,12 +178,11 @@ class TestsViewStore: XCTestCase {
     /// Test creating binding from a ViewStore
     func testViewStoreBinding() throws {
         let store = Store(
-            update: ParentModel.update,
             state: ParentModel(),
             environment: ()
         )
 
-        let viewStore: ViewStore<ChildModel, ChildAction> = ViewStore(
+        let viewStore: ViewStore<ChildModel> = ViewStore(
             store: store,
             cursor: ParentChildCursor.self
         )
@@ -221,7 +214,6 @@ class TestsViewStore: XCTestCase {
 
     func testCursorUpdateTransaction() throws {
         let update = ParentChildCursor.update(
-            with: ChildModel.update,
             state: ParentModel(),
             action: ChildAction.setText("Foo"),
             environment: ()

--- a/Tests/ObservableStoreTests/ViewStoreTests.swift
+++ b/Tests/ObservableStoreTests/ViewStoreTests.swift
@@ -147,34 +147,6 @@ class TestsViewStore: XCTestCase {
         )
     }
 
-    /// Test creating binding from a root Store
-    func testStoreBinding() throws {
-        let store = Store(
-            state: ParentModel(),
-            environment: ()
-        )
-
-        let binding = Binding(
-            store: store,
-            get: \.child.text,
-            tag: ParentAction.setText
-        )
-
-        let view = SimpleView(text: binding)
-
-        view.text = "Foo"
-        view.text = "Bar"
-
-        XCTAssertEqual(
-            store.state.child.text,
-            "Bar"
-        )
-        XCTAssertEqual(
-            store.state.edits,
-            2
-        )
-    }
-
     /// Test creating binding from a ViewStore
     func testViewStoreBinding() throws {
         let store = Store(

--- a/Tests/ObservableStoreTests/ViewStoreTests.swift
+++ b/Tests/ObservableStoreTests/ViewStoreTests.swift
@@ -1,0 +1,234 @@
+//
+//  ViewStoreTests.swift
+//  
+//
+//  Created by Gordon Brander on 9/12/22.
+//
+
+import XCTest
+import Combine
+import SwiftUI
+@testable import ObservableStore
+
+class TestsViewStore: XCTestCase {
+    enum ParentAction: Hashable {
+        case child(ChildAction)
+        case setText(String)
+    }
+
+    struct ParentModel: Equatable {
+        var child = ChildModel(text: "")
+        var edits: Int = 0
+
+        static func update(
+            state: ParentModel,
+            action: ParentAction,
+            environment: Void
+        ) -> Update<ParentModel, ParentAction> {
+            switch action {
+            case .child(let action):
+                return ParentChildCursor.update(
+                    with: ChildModel.update,
+                    state: state,
+                    action: action,
+                    environment: ()
+                )
+            case .setText(let text):
+                var next = ParentChildCursor.update(
+                    with: ChildModel.update,
+                    state: state,
+                    action: .setText(text),
+                    environment: ()
+                )
+                next.state.edits = next.state.edits + 1
+                return next
+            }
+        }
+    }
+
+    struct ParentChildCursor: CursorProtocol {
+        static func get(state: ParentModel) -> ChildModel {
+            state.child
+        }
+
+        static func set(state: ParentModel, inner: ChildModel) -> ParentModel {
+            var model = state
+            model.child = inner
+            return model
+        }
+
+        static func tag(_ action: ChildAction) -> ParentAction {
+            switch action {
+            case .setText(let string):
+                return .setText(string)
+            }
+        }
+    }
+
+    struct ChildModel: Hashable {
+        var text: String
+
+        static func update(
+            state: ChildModel,
+            action: ChildAction,
+            environment: Void
+        ) -> Update<ChildModel, ChildAction> {
+            switch action {
+            case .setText(let string):
+                var model = state
+                model.text = string
+                return Update(state: model)
+                    .animation(.default)
+            }
+        }
+    }
+
+    enum ChildAction: Hashable {
+        case setText(String)
+    }
+
+    struct SimpleView: View {
+        @Binding var text: String
+
+        var body: some View {
+            Text(text)
+        }
+    }
+
+    func testViewStoreCursor() throws {
+        let store = Store(
+            update: ParentModel.update,
+            state: ParentModel(),
+            environment: ()
+        )
+
+        let viewStore: ViewStore<ChildModel, ChildAction> = ViewStore(
+            store: store,
+            cursor: ParentChildCursor.self
+        )
+
+        viewStore.send(.setText("Foo"))
+        viewStore.send(.setText("Bar"))
+        XCTAssertEqual(
+            viewStore.state.text,
+            "Bar"
+        )
+        XCTAssertEqual(
+            store.state.child.text,
+            "Bar"
+        )
+        XCTAssertEqual(
+            store.state.edits,
+            2
+        )
+    }
+
+    func testViewStoreGetTag() throws {
+        let store = Store(
+            update: ParentModel.update,
+            state: ParentModel(),
+            environment: ()
+        )
+
+        let viewStore: ViewStore<ChildModel, ChildAction> = ViewStore(
+            store: store,
+            get: { state in state.child },
+            tag: ParentChildCursor.tag
+        )
+
+        viewStore.send(.setText("Foo"))
+        viewStore.send(.setText("Bar"))
+        XCTAssertEqual(
+            viewStore.state.text,
+            "Bar"
+        )
+        XCTAssertEqual(
+            store.state.child.text,
+            "Bar"
+        )
+        XCTAssertEqual(
+            store.state.edits,
+            2
+        )
+    }
+
+    /// Test creating binding from a root Store
+    func testStoreBinding() throws {
+        let store = Store(
+            update: ParentModel.update,
+            state: ParentModel(),
+            environment: ()
+        )
+
+        let binding = Binding(
+            store: store,
+            get: \.child.text,
+            tag: ParentAction.setText
+        )
+
+        let view = SimpleView(text: binding)
+
+        view.text = "Foo"
+        view.text = "Bar"
+
+        XCTAssertEqual(
+            store.state.child.text,
+            "Bar"
+        )
+        XCTAssertEqual(
+            store.state.edits,
+            2
+        )
+    }
+
+    /// Test creating binding from a ViewStore
+    func testViewStoreBinding() throws {
+        let store = Store(
+            update: ParentModel.update,
+            state: ParentModel(),
+            environment: ()
+        )
+
+        let viewStore: ViewStore<ChildModel, ChildAction> = ViewStore(
+            store: store,
+            cursor: ParentChildCursor.self
+        )
+
+        let binding = Binding(
+            store: viewStore,
+            get: \.text,
+            tag: ChildAction.setText
+        )
+
+        let view = SimpleView(text: binding)
+
+        view.text = "Foo"
+        view.text = "Bar"
+
+        XCTAssertEqual(
+            viewStore.state.text,
+            "Bar"
+        )
+        XCTAssertEqual(
+            store.state.child.text,
+            "Bar"
+        )
+        XCTAssertEqual(
+            store.state.edits,
+            2
+        )
+    }
+
+    func testCursorUpdateTransaction() throws {
+        let update = ParentChildCursor.update(
+            with: ChildModel.update,
+            state: ParentModel(),
+            action: ChildAction.setText("Foo"),
+            environment: ()
+        )
+        XCTAssertNotNil(
+            update.transaction,
+            "Transaction is preserved by cursor"
+        )
+    }
+}

--- a/Tests/ObservableStoreTests/ViewStoreTests.swift
+++ b/Tests/ObservableStoreTests/ViewStoreTests.swift
@@ -132,8 +132,7 @@ class TestsViewStore: XCTestCase {
 
         let viewStore: ViewStore<ChildModel, ChildAction> = ViewStore(
             store: store,
-            get: { state in state.child },
-            tag: ParentChildCursor.tag
+            cursor: ParentChildCursor.self
         )
 
         viewStore.send(.setText("Foo"))


### PR DESCRIPTION
This PR introduces the ability to create scoped stores for sub-components, called `ViewStores`. `ViewStores` are conceptually like bindings for stores, except that they expose the store API, instead of a binding API. This approach is inspired by the component mapping pattern from Elm.

We also update the implementation of Store so that fx are run immediately instead of being joined on main queue. This is to avoid adding delay when intercepting child actions and then sending them back up as fx.

## Changes

- Introduce `ModelProtocol`, which implements an `update(state:action:environment)` static function.
   - Model protocol allows us to treat action and environment as associatedtypes, which simplifies many of our other type signatures.
- Introduce `StoreProtocol`, a protocol that describes a kind of store.
- Introduce `ViewStore<Model: ModelProtocol>`, which implements `StoreProtocol`
- Implement `StoreProtocol` for `Store`
- Introduce `CursorProtocol`, which describes how to map from one domain to another, and provides a convenience function for updating child components.
- Replace `.binding` with generic Binding intializer for any StoreProtocol
- Add new tests


## Breaking changes

- Fx are now run immediately, meaning you will have to manually join asyncronous fx to main queue with `.receive(on: DispatchQueue.main)`
- Store requires that state implement `ModelProtocol`. This allows us to simplify the signatures of many other APIs
    - Update type signature changes from `Update<State, Action>` to `Update<Model: ModelProtocol>`.
    - Store type signature changes from `Store<State, Action, Environment>` to `Store<Model: ModelProtocol>`
    - Store initializer changes from `Store.init(update:state:environment:)` to `Store.init(state:environment:)`. Now that state conforms to `ModelProtocol`, you don't have to explicitly pass in the update function as a closure. We can just call the protocol implementation.
- `store.binding` has been removed in favor of `Binding(store:get:send:)`