### PR TITLE
Introduce KeyedCursorProtocol, remove ViewStore in favor of forward

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -294,20 +294,19 @@ extension CursorProtocol {
 //  guts of UIViewRepresentable.
 //  2022-06-12 Gordon Brander
 public struct ViewStore<ViewModel: ModelProtocol>: StoreProtocol {
-    private let _get: () -> ViewModel
     private let _send: (ViewModel.Action) -> Void
 
     /// Initialize a ViewStore using a get and send closure.
     public init(
-        get: @escaping () -> ViewModel,
+        get: () -> ViewModel,
         send: @escaping (ViewModel.Action) -> Void
     ) {
-        self._get = get
+        self.state = get()
         self._send = send
     }
 
     /// Get current state
-    public var state: ViewModel { self._get() }
+    public let state: ViewModel
 
     /// Send an action
     public func send(_ action: ViewModel.Action) {

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -395,12 +395,12 @@ extension KeyedCursorProtocol {
 
 extension Binding {
     /// Initialize a Binding from a store.
-    /// - `get` reads the store state to a binding value.
-    /// - `send` sends the value to some address.
-    /// - `tag` tags the value, turning it into an action
+    /// - `get` reads the binding value.
+    /// - `send` sends actions to some address.
+    /// - `tag` tags the value, turning it into an action for `send`
     /// - Returns a binding suitable for use in a vanilla SwiftUI view.
     public init<Action>(
-        state get: @escaping @autoclosure () -> Value,
+        get: @escaping () -> Value,
         send: @escaping (Action) -> Void,
         tag: @escaping (Value) -> Action
     ) {

--- a/Tests/ObservableStoreTests/BindingTests.swift
+++ b/Tests/ObservableStoreTests/BindingTests.swift
@@ -49,7 +49,7 @@ final class BindingTests: XCTestCase {
         )
 
         let binding = Binding(
-            state: store.state.text,
+            get: { store.state.text },
             send: store.send,
             tag: Action.setText
         )

--- a/Tests/ObservableStoreTests/BindingTests.swift
+++ b/Tests/ObservableStoreTests/BindingTests.swift
@@ -1,0 +1,71 @@
+//
+//  BindingTests.swift
+//  
+//
+//  Created by Gordon Brander on 9/21/22.
+//
+
+import XCTest
+import SwiftUI
+@testable import ObservableStore
+
+final class BindingTests: XCTestCase {
+    enum Action: Hashable {
+        case setText(String)
+    }
+
+    struct Model: ModelProtocol {
+        var text = ""
+        var edits: Int = 0
+
+        static func update(
+            state: Model,
+            action: Action,
+            environment: Void
+        ) -> Update<Model> {
+            switch action {
+            case .setText(let text):
+                var model = state
+                model.text = text
+                model.edits = model.edits + 1
+                return Update(state: model)
+            }
+        }
+    }
+
+    struct SimpleView: View {
+        @Binding var text: String
+
+        var body: some View {
+            Text(text)
+        }
+    }
+
+    /// Test creating binding for an address
+    func testBinding() throws {
+        let store = Store(
+            state: Model(),
+            environment: ()
+        )
+
+        let binding = Binding(
+            state: store.state.text,
+            send: store.send,
+            tag: Action.setText
+        )
+
+        let view = SimpleView(text: binding)
+
+        view.text = "Foo"
+        view.text = "Bar"
+
+        XCTAssertEqual(
+            store.state.text,
+            "Bar"
+        )
+        XCTAssertEqual(
+            store.state.edits,
+            2
+        )
+    }
+}

--- a/Tests/ObservableStoreTests/ComponentMappingTests.swift
+++ b/Tests/ObservableStoreTests/ComponentMappingTests.swift
@@ -10,7 +10,7 @@ import Combine
 import SwiftUI
 @testable import ObservableStore
 
-class TestsViewStore: XCTestCase {
+class ComponentMappingTests: XCTestCase {
     enum ParentAction: Hashable {
         case child(ChildAction)
         case setText(String)
@@ -85,95 +85,20 @@ class TestsViewStore: XCTestCase {
         }
     }
 
-    struct SimpleView: View {
-        @Binding var text: String
-
-        var body: some View {
-            Text(text)
-        }
-    }
-
-    func testViewStoreCursor() throws {
+    func testForward() throws {
         let store = Store(
             state: ParentModel(),
             environment: ()
         )
 
-        let viewStore: ViewStore<ChildModel> = ViewStore(
-            store: store,
-            cursor: ParentChildCursor.self
+        let send = Address.forward(
+            send: store.send,
+            tag: ParentChildCursor.tag
         )
 
-        viewStore.send(.setText("Foo"))
-        viewStore.send(.setText("Bar"))
-        XCTAssertEqual(
-            viewStore.state.text,
-            "Bar"
-        )
-        XCTAssertEqual(
-            store.state.child.text,
-            "Bar"
-        )
-        XCTAssertEqual(
-            store.state.edits,
-            2
-        )
-    }
+        send(.setText("Foo"))
+        send(.setText("Bar"))
 
-    func testViewStoreGetTag() throws {
-        let store = Store(
-            state: ParentModel(),
-            environment: ()
-        )
-
-        let viewStore: ViewStore<ChildModel> = ViewStore(
-            store: store,
-            cursor: ParentChildCursor.self
-        )
-
-        viewStore.send(.setText("Foo"))
-        viewStore.send(.setText("Bar"))
-        XCTAssertEqual(
-            viewStore.state.text,
-            "Bar"
-        )
-        XCTAssertEqual(
-            store.state.child.text,
-            "Bar"
-        )
-        XCTAssertEqual(
-            store.state.edits,
-            2
-        )
-    }
-
-    /// Test creating binding from a ViewStore
-    func testViewStoreBinding() throws {
-        let store = Store(
-            state: ParentModel(),
-            environment: ()
-        )
-
-        let viewStore: ViewStore<ChildModel> = ViewStore(
-            store: store,
-            cursor: ParentChildCursor.self
-        )
-
-        let binding = Binding(
-            store: viewStore,
-            get: \.text,
-            tag: ChildAction.setText
-        )
-
-        let view = SimpleView(text: binding)
-
-        view.text = "Foo"
-        view.text = "Bar"
-
-        XCTAssertEqual(
-            viewStore.state.text,
-            "Bar"
-        )
         XCTAssertEqual(
             store.state.child.text,
             "Bar"

--- a/Tests/ObservableStoreTests/ComponentMappingTests.swift
+++ b/Tests/ObservableStoreTests/ComponentMappingTests.swift
@@ -13,13 +13,15 @@ import SwiftUI
 class ComponentMappingTests: XCTestCase {
     enum ParentAction: Hashable {
         case child(ChildAction)
+        case keyedChild(action: ChildAction, key: String)
         case setText(String)
     }
-
+    
     struct ParentModel: ModelProtocol {
         var child = ChildModel(text: "")
+        var keyedChildren: [String: ChildModel] = [:]
         var edits: Int = 0
-
+        
         static func update(
             state: ParentModel,
             action: ParentAction,
@@ -32,6 +34,13 @@ class ComponentMappingTests: XCTestCase {
                     action: action,
                     environment: ()
                 )
+            case let .keyedChild(action, key):
+                return KeyedParentChildCursor.update(
+                    state: state,
+                    action: action,
+                    environment: (),
+                    key: key
+                )
             case .setText(let text):
                 var next = ParentChildCursor.update(
                     state: state,
@@ -43,14 +52,14 @@ class ComponentMappingTests: XCTestCase {
             }
         }
     }
-
+    
     enum ChildAction: Hashable {
         case setText(String)
     }
-
+    
     struct ChildModel: ModelProtocol {
         var text: String
-
+        
         static func update(
             state: ChildModel,
             action: ChildAction,
@@ -65,18 +74,18 @@ class ComponentMappingTests: XCTestCase {
             }
         }
     }
-
+    
     struct ParentChildCursor: CursorProtocol {
         static func get(state: ParentModel) -> ChildModel {
             state.child
         }
-
+        
         static func set(state: ParentModel, inner: ChildModel) -> ParentModel {
             var model = state
             model.child = inner
             return model
         }
-
+        
         static func tag(_ action: ChildAction) -> ParentAction {
             switch action {
             case .setText(let string):
@@ -84,21 +93,41 @@ class ComponentMappingTests: XCTestCase {
             }
         }
     }
-
+    
+    struct KeyedParentChildCursor: KeyedCursorProtocol {
+        static func get(state: ParentModel, key: String) -> ChildModel? {
+            state.keyedChildren[key]
+        }
+        
+        static func set(
+            state: ParentModel,
+            inner: ChildModel,
+            key: String
+        ) -> ParentModel {
+            var model = state
+            model.keyedChildren[key] = inner
+            return model
+        }
+        
+        static func tag(action: ChildAction, key: String) -> ParentAction {
+            .keyedChild(action: action, key: key)
+        }
+    }
+    
     func testForward() throws {
         let store = Store(
             state: ParentModel(),
             environment: ()
         )
-
+        
         let send = Address.forward(
             send: store.send,
             tag: ParentChildCursor.tag
         )
-
+        
         send(.setText("Foo"))
         send(.setText("Bar"))
-
+        
         XCTAssertEqual(
             store.state.child.text,
             "Bar"
@@ -108,12 +137,92 @@ class ComponentMappingTests: XCTestCase {
             2
         )
     }
-
+    
+    func testKeyedCursorUpdate() throws {
+        let store = Store(
+            state: ParentModel(
+                keyedChildren: [
+                    "a": ChildModel(text: "A"),
+                    "b": ChildModel(text: "B"),
+                    "c": ChildModel(text: "C"),
+                ]
+            ),
+            environment: ()
+        )
+        store.send(.keyedChild(action: .setText("BBB"), key: "a"))
+        store.send(.keyedChild(action: .setText("AAA"), key: "a"))
+        XCTAssertEqual(
+            store.state.keyedChildren["a"]?.text,
+            "AAA",
+            "KeyedCursor updates model at key"
+        )
+    }
+    
     func testCursorUpdateTransaction() throws {
         let update = ParentChildCursor.update(
             state: ParentModel(),
             action: ChildAction.setText("Foo"),
             environment: ()
+        )
+        XCTAssertNotNil(
+            update.transaction,
+            "Transaction is preserved by cursor"
+        )
+    }
+    
+    func testCursorUpdate() throws {
+        let store = Store(
+            state: ParentModel(),
+            environment: ()
+        )
+        store.send(.setText("Woo"))
+        store.send(.setText("Woo"))
+        XCTAssertEqual(
+            store.state.child.text,
+            "Woo",
+            "Cursor updates child model"
+        )
+        XCTAssertEqual(
+            store.state.edits,
+            2
+        )
+    }
+    
+    func testKeyedCursorUpdateMissing() throws {
+        let store = Store(
+            state: ParentModel(
+                keyedChildren: [
+                    "a": ChildModel(text: "A"),
+                    "b": ChildModel(text: "B"),
+                    "c": ChildModel(text: "C"),
+                ]
+            ),
+            environment: ()
+        )
+        store.send(.keyedChild(action: .setText("ZZZ"), key: "z"))
+        XCTAssertEqual(
+            store.state.keyedChildren.count,
+            3,
+            "KeyedCursor update does nothing if key is missing"
+        )
+        XCTAssertNil(
+            store.state.keyedChildren["z"],
+            "KeyedCursor update does nothing if key is missing"
+        )
+    }
+    
+    func testKeyedCursorUpdateTransaction() throws {
+        let update: Update<ParentModel> = KeyedParentChildCursor.update(
+            state: ParentModel(
+                keyedChildren: [
+                    "a": ChildModel(text: "A"),
+                    "b": ChildModel(text: "B"),
+                    "c": ChildModel(text: "C"),
+                ]
+            ),
+            action: .setText("Foo"),
+            environment: (),
+            key: "a"
         )
         XCTAssertNotNil(
             update.transaction,

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -91,43 +91,6 @@ final class ObservableStoreTests: XCTestCase {
         XCTAssertEqual(store.state.count, 1, "state is advanced")
     }
 
-    func testBinding() throws {
-        let store = Store(
-            state: AppModel(),
-            environment: AppModel.Environment()
-        )
-        let view = SimpleCountView(
-            count: Binding(
-                store: store,
-                get: \.count,
-                tag: AppModel.Action.setCount
-            )
-        )
-        view.count = 2
-        XCTAssertEqual(view.count, 2, "binding is set")
-        XCTAssertEqual(store.state.count, 2, "binding sends action to store")
-    }
-
-    func testDeepBinding() throws {
-        let store = Store(
-            state: AppModel(),
-            environment: AppModel.Environment()
-        )
-        let binding = Binding(
-            store: store,
-            get: \.editor,
-            tag: AppModel.Action.setEditor
-        )
-        .input
-        .text
-        binding.wrappedValue = "floop"
-        XCTAssertEqual(
-            store.state.editor.input.text,
-            "floop",
-            "specialized binding sets deep property"
-        )
-    }
-
     func testEmptyFxRemovedOnComplete() {
         let store = Store(
             state: AppModel(),


### PR DESCRIPTION
Fixes #18.

This PR sketches out one potential solution to #18. It refactors our approach to sub-components by decomplecting action sending from state getting.

- Removes `ViewStore`
- Introduces `Address.forward(send:tag:)` which gives us an easy way to create tagged `send` functions. This solves one part of what ViewStore was solving.
- Introduces `Binding(get:send:tag:)` which gives us the binding equivalent to `Address.forward`
- Introduces `KeyedCursorProtocol` which offers an alternative cursor for subcomponents that need to be looked up within dynamic lists.

This refactor is in response to the awkwardness of the `ViewStore/Cursor` paradigm for components that are part of a dynamic list. Even if we had created a keyed cursor initializer for ViewStore, it necessarily would have had to hold an optional (nillable) state. This is because ViewStore lookup was dynamic, and this trips up the lifetime typechecking around the model. In practice, a view would not exist if its model did not exist, but this is not a typesafe guarantee for dynamic list lookups.

Anyway, the whole paradigm of looking up child from parent dynamically is a bit odd for list items. In SwiftUI the typical approach is to ForEach, and then pass the model data down as a static property to the view. This guarantees type safety, since a view holds its own copy of the data. What if we could do something more like that?

The approach in this PR leans into this approach. State can be passed to sub-components as plain old properties. `Address.forward` can be used to create view-local send functions that you can pass down to sub-views. `Binding` gets a similar form. In both cases, we can use a closure to capture additional parent-scoped state, such as an ID for lookup within the parent model.

Cursor sticks around, but mostly as a convenient way to create update functions for sub-components. We also introduce `KeyedCursorProtocol` which offers a keyed equivalent for dynamic lookup.

## Usage

Sub-components become more "vanilla", just using bare properties and closures.

```swift
struct ParentView: View {
    @StateObject = Store(
        AppModel(),
        AppEnvironment()
    )

    var body: some View {
        ChildModel(
            state: store.state.child,
            send: Address.forward(
                send: store.send,
                tag: ParentChildCursor.tag
            )
        )
    }
}

struct ChildView: View {
    var state: ChildModel
    var send: (ChildAction) -> Void

    var body: some View {
        Button(state.text) {
            send(.activate)
        }
    }
}
```

## Prior art

This approach is inspired by Reflex:

- Forward https://github.com/mozilla/reflex/blob/c5e75e98bc601e2315b6d43e5e347263cf67359e/src/signal.js#L5
- Cursor https://github.com/browserhtml/browserhtml/blob/master/src/Common/Cursor.js