### PR TITLE
Remove CursorProtocol in favor of new update function

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -278,7 +278,7 @@ public struct Cursor {
     /// - `action` the inner action
     /// - `environment` the environment for the update function
     /// - Returns a new outer state
-    public func update<Model: ModelProtocol, ViewModel: ModelProtocol>(
+    public static func update<Model: ModelProtocol, ViewModel: ModelProtocol>(
         get: (Model) -> ViewModel?,
         set: (Model, ViewModel) -> Model,
         tag: @escaping (ViewModel.Action) -> Model.Action,


### PR DESCRIPTION
This PR removes CursorProtocol in favor of a static `Cursor.update(get:set:tag:state:action:environment)` function. This function accepts getters which return an optional state, supporting the array lookup case.

## Rationale

- Removing `CursorProtocol` is in keeping with the more "vanilla" approach to defining subcomponents introduced in #19. We don't need a special protocol or datatype when vanilla SwiftUI patterns will do. Synthesizing update functions and having two cursor types was confusing. By contrast, using closures is well-understood, and still leaves open the possibility of defining your cursor types in a separate struct.
- Additionally, these child update functions are only called in one place, so defining a cursor separately may be additional cognitive overhead.
- Only `tag` needs to be escaping. The`get` and `set` closures are essentially no overhead.

## Added

- `Cursor.update(get:set:tag:state:action:environment)`

## Breaking changes

- `Address.forward` becomes `Cursor.forward`
- `CursorProtocol` removed
- `KeyedCursorProtocol` removed