### PR TITLE
Reintroduce ViewStore, remove CursorProtocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,16 +311,16 @@ struct AppModel: ModelProtocol {
     var child = ChildModel()
 
     static func update(
-        get: AppChildCursor.get,
-        set: AppChildCursor.set,
-        tag: AppChildCursor.tag,
         state: AppModel,
         action: AppAction,
         environment: AppEnvironment
     ) -> Update<AppModel> {
         switch {
         case .child(let action):
-            return AppChildCursor.update(
+            return update(
+                get: AppChildCursor.get,
+                set: AppChildCursor.set,
+                tag: AppChildCursor.tag,
                 state: state,
                 action: action,
                 environment: ()

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -329,7 +329,7 @@ extension ViewStore {
 
 extension StoreProtocol {
     /// Create a viewStore from a StoreProtocol
-    func viewStore<ViewModel: ModelProtocol>(
+    public func viewStore<ViewModel: ModelProtocol>(
         get: (Self.Model) -> ViewModel,
         tag: @escaping (ViewModel.Action) -> Self.Model.Action
     ) -> ViewStore<ViewModel> {
@@ -372,7 +372,7 @@ extension Binding {
 }
 
 extension StoreProtocol {
-    func binding<Value>(
+    public func binding<Value>(
         get: @escaping (Self.Model) -> Value,
         tag: @escaping (Value) -> Self.Model.Action
     ) -> Binding<Value> {

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -54,6 +54,45 @@ extension ModelProtocol {
     }
 }
 
+extension ModelProtocol {
+    /// Update a child state within a parent state.
+    /// This update offers a convenient way to call child update functions
+    /// from the parent domain, and get parent-domain states and actions
+    /// back from it.
+    ///
+    /// - `get` gets the child's state
+    /// - `set` sets the child's state within the parent state
+    /// - `tag` tags child actions, turning them into parent actions
+    /// - `state` the outer state
+    /// - `action` the inner action
+    /// - `environment` the environment for the update function
+    /// - Returns a new outer state
+    public static func update<ViewModel: ModelProtocol>(
+        get: (Self) -> ViewModel?,
+        set: (Self, ViewModel) -> Self,
+        tag: @escaping (ViewModel.Action) -> Self.Action,
+        state: Self,
+        action viewAction: ViewModel.Action,
+        environment: ViewModel.Environment
+    ) -> Update<Self> {
+        // If getter returns nil (as in case of a list item that no longer
+        // exists), do nothing.
+        guard let inner = get(state) else {
+            return Update(state: state)
+        }
+        let next = ViewModel.update(
+            state: inner,
+            action: viewAction,
+            environment: environment
+        )
+        return Update(
+            state: set(state, next.state),
+            fx: next.fx.map(tag).eraseToAnyPublisher(),
+            transaction: next.transaction
+        )
+    }
+}
+
 /// Update represents a state change, together with an `Fx` publisher,
 /// and an optional `Transaction`.
 public struct Update<Model: ModelProtocol> {
@@ -258,6 +297,90 @@ where Model: ModelProtocol
     }
 }
 
+public struct ViewStore<ViewModel: ModelProtocol>: StoreProtocol {
+    private var _send: (ViewModel.Action) -> Void
+    public var state: ViewModel
+
+    init(
+        state: ViewModel,
+        send: @escaping (ViewModel.Action) -> Void
+    ) {
+        self.state = state
+        self._send = send
+    }
+        
+    public func send(_ action: ViewModel.Action) {
+        self._send(action)
+    }
+}
+
+extension ViewStore {
+    init<Action>(
+        state: ViewModel,
+        send: @escaping (Action) -> Void,
+        tag: @escaping (ViewModel.Action) -> Action
+    ) {
+        self.init(
+            state: state,
+            send: { action in send(tag(action)) }
+        )
+    }
+}
+
+extension StoreProtocol {
+    /// Create a viewStore from a StoreProtocol
+    func viewStore<ViewModel: ModelProtocol>(
+        get: (Self.Model) -> ViewModel,
+        tag: @escaping (ViewModel.Action) -> Self.Model.Action
+    ) -> ViewStore<ViewModel> {
+        ViewStore(
+            state: get(self.state),
+            send: self.send,
+            tag: tag
+        )
+    }
+}
+
+public protocol CursorProtocol {
+    associatedtype Model: ModelProtocol
+    associatedtype ViewModel: ModelProtocol
+    
+    func get(_ state: Model) -> ViewModel?
+    
+    func set(_ state: Model, _ inner: ViewModel) -> Model
+    
+    func tag(_ action: ViewModel.Action) -> Model.Action
+}
+
+extension ModelProtocol {
+    /// Update an outer state through a cursor.
+    /// Offers a convenient way to call child update functions from the
+    /// parent domain, and get parent-domain states and actions back from it.
+    ///
+    /// - `cursor` Any type that conforms to CursorProtocol
+    /// - `state` the outer state
+    /// - `action` the inner action
+    /// - `environment` the environment for the update function
+    /// - Returns a new outer state
+    public static func update<Cursor: CursorProtocol>(
+        cursor: Cursor,
+        state: Self,
+        action viewAction: Cursor.ViewModel.Action,
+        environment: Cursor.ViewModel.Environment
+    ) -> Update<Self>
+    where Cursor.Model == Self
+    {
+        update(
+            get: cursor.get,
+            set: cursor.set,
+            tag: cursor.tag,
+            state: state,
+            action: viewAction,
+            environment: environment
+        )
+    }
+}
+
 public struct Address {
     /// Forward transform an address (send function) into a local address.
     /// View-scoped actions are tagged using `tag` before being forwarded to
@@ -267,129 +390,6 @@ public struct Address {
         tag: @escaping (ViewAction) -> Action
     ) -> (ViewAction) -> Void {
         { viewAction in send(tag(viewAction)) }
-    }
-}
-
-/// A cursor provides a complete description of how to map from one component
-/// domain to another.
-public protocol CursorProtocol {
-    associatedtype Model: ModelProtocol
-    associatedtype ViewModel: ModelProtocol
-
-    /// Get an inner state from an outer state
-    static func get(state: Model) -> ViewModel
-
-    /// Set an inner state on an outer state, returning an outer state
-    static func set(state: Model, inner: ViewModel) -> Model
-
-    /// Tag an inner action, transforming it into an outer action
-    static func tag(_ action: ViewModel.Action) -> Model.Action
-}
-
-extension CursorProtocol {
-    /// Update an outer state through a cursor.
-    /// CursorProtocol.update offers a convenient way to call child
-    /// update functions from the parent domain, and get parent-domain
-    /// states and actions back from it.
-    ///
-    /// - `state` the outer state
-    /// - `action` the inner action
-    /// - `environment` the environment for the update function
-    /// - Returns a new outer state
-    public static func update(
-        state: Model,
-        action viewAction: ViewModel.Action,
-        environment: ViewModel.Environment
-    ) -> Update<Model> {
-        let next = ViewModel.update(
-            state: get(state: state),
-            action: viewAction,
-            environment: environment
-        )
-        return Update(
-            state: set(state: state, inner: next.state),
-            fx: next.fx.map(tag).eraseToAnyPublisher(),
-            transaction: next.transaction
-        )
-    }
-}
-
-public protocol KeyedCursorProtocol {
-    associatedtype Key
-    associatedtype Model: ModelProtocol
-    associatedtype ViewModel: ModelProtocol
-
-    /// Get an inner state from an outer state
-    static func get(state: Model, key: Key) -> ViewModel?
-
-    /// Set an inner state on an outer state, returning an outer state
-    static func set(state: Model, inner: ViewModel, key: Key) -> Model
-
-    /// Tag an inner action, transforming it into an outer action
-    static func tag(action: ViewModel.Action, key: Key) -> Model.Action
-}
-
-extension KeyedCursorProtocol {
-    /// Update an inner state within an outer state through a keyed cursor.
-    /// This cursor type is useful when looking up children in dynamic lists
-    /// such as arrays or dictionaries.
-    ///
-    /// - `state` the outer state
-    /// - `action` the inner action
-    /// - `environment` the environment for the update function
-    /// - `key` a key uniquely representing this model in the parent domain
-    /// - Returns an update for a new outer state or nil
-    public static func update(
-        state: Model,
-        action viewAction: ViewModel.Action,
-        environment viewEnvironment: ViewModel.Environment,
-        key: Key
-    ) -> Update<Model>? {
-        guard let viewModel = get(state: state, key: key) else {
-            return nil
-        }
-        let next = ViewModel.update(
-            state: viewModel,
-            action: viewAction,
-            environment: viewEnvironment
-        )
-        return Update(
-            state: set(state: state, inner: next.state, key: key),
-            fx: next.fx
-                .map({ viewAction in Self.tag(action: viewAction, key: key) })
-                .eraseToAnyPublisher(),
-            transaction: next.transaction
-        )
-    }
-
-    /// Update an inner state within an outer state through a keyed cursor.
-    /// This cursor type is useful when looking up children in dynamic lists
-    /// such as arrays or dictionaries.
-    ///
-    /// This version of update always returns an `Update`. If the child model
-    /// cannot be found at key, then it returns an update for the same state
-    /// (noop), effectively ignoring the action.
-    ///
-    /// - `state` the outer state
-    /// - `action` the inner action
-    /// - `environment` the environment for the update function
-    /// - `key` a key uniquely representing this model in the parent domain
-    /// - Returns an update for a new outer state or nil
-    public static func update(
-        state: Model,
-        action viewAction: ViewModel.Action,
-        environment viewEnvironment: ViewModel.Environment,
-        key: Key
-    ) -> Update<Model> {
-        guard let next = update(
-            state: state,
-            action: viewAction,
-            environment: viewEnvironment,
-            key: key
-        ) else {
-            return Update(state: state)
-        }
-        return next
     }
 }
 

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -301,7 +301,7 @@ public struct ViewStore<ViewModel: ModelProtocol>: StoreProtocol {
     private var _send: (ViewModel.Action) -> Void
     public var state: ViewModel
 
-    init(
+    public init(
         state: ViewModel,
         send: @escaping (ViewModel.Action) -> Void
     ) {
@@ -315,7 +315,7 @@ public struct ViewStore<ViewModel: ModelProtocol>: StoreProtocol {
 }
 
 extension ViewStore {
-    init<Action>(
+    public init<Action>(
         state: ViewModel,
         send: @escaping (Action) -> Void,
         tag: @escaping (ViewModel.Action) -> Action
@@ -337,46 +337,6 @@ extension StoreProtocol {
             state: get(self.state),
             send: self.send,
             tag: tag
-        )
-    }
-}
-
-public protocol CursorProtocol {
-    associatedtype Model: ModelProtocol
-    associatedtype ViewModel: ModelProtocol
-    
-    func get(_ state: Model) -> ViewModel?
-    
-    func set(_ state: Model, _ inner: ViewModel) -> Model
-    
-    func tag(_ action: ViewModel.Action) -> Model.Action
-}
-
-extension ModelProtocol {
-    /// Update an outer state through a cursor.
-    /// Offers a convenient way to call child update functions from the
-    /// parent domain, and get parent-domain states and actions back from it.
-    ///
-    /// - `cursor` Any type that conforms to CursorProtocol
-    /// - `state` the outer state
-    /// - `action` the inner action
-    /// - `environment` the environment for the update function
-    /// - Returns a new outer state
-    public static func update<Cursor: CursorProtocol>(
-        cursor: Cursor,
-        state: Self,
-        action viewAction: Cursor.ViewModel.Action,
-        environment: Cursor.ViewModel.Environment
-    ) -> Update<Self>
-    where Cursor.Model == Self
-    {
-        update(
-            get: cursor.get,
-            set: cursor.set,
-            tag: cursor.tag,
-            state: state,
-            action: viewAction,
-            environment: environment
         )
     }
 }
@@ -407,6 +367,18 @@ extension Binding {
         self.init(
             get: get,
             set: { value in send(tag(value)) }
+        )
+    }
+}
+
+extension StoreProtocol {
+    func binding<Value>(
+        get: @escaping (Self.Model) -> Value,
+        tag: @escaping (Value) -> Self.Model.Action
+    ) -> Binding<Value> {
+        Binding(
+            get: { get(self.state) },
+            set: { value in self.send(tag(value)) }
         )
     }
 }

--- a/Tests/ObservableStoreTests/BindingTests.swift
+++ b/Tests/ObservableStoreTests/BindingTests.swift
@@ -13,11 +13,11 @@ final class BindingTests: XCTestCase {
     enum Action: Hashable {
         case setText(String)
     }
-
+    
     struct Model: ModelProtocol {
         var text = ""
         var edits: Int = 0
-
+        
         static func update(
             state: Model,
             action: Action,
@@ -32,25 +32,52 @@ final class BindingTests: XCTestCase {
             }
         }
     }
-
+    
     struct SimpleView: View {
         @Binding var text: String
-
+        
         var body: some View {
             Text(text)
         }
     }
-
+    
     /// Test creating binding for an address
     func testBinding() throws {
         let store = Store(
             state: Model(),
             environment: ()
         )
-
+        
         let binding = Binding(
             get: { store.state.text },
             send: store.send,
+            tag: Action.setText
+        )
+        
+        let view = SimpleView(text: binding)
+        
+        view.text = "Foo"
+        view.text = "Bar"
+        
+        XCTAssertEqual(
+            store.state.text,
+            "Bar"
+        )
+        XCTAssertEqual(
+            store.state.edits,
+            2
+        )
+    }
+    
+    /// Test creating binding for an address
+    func testBindingMethod() throws {
+        let store = Store(
+            state: Model(),
+            environment: ()
+        )
+
+        let binding = store.binding(
+            get: \.text,
             tag: Action.setText
         )
 

--- a/Tests/ObservableStoreTests/ComponentMappingTests.swift
+++ b/Tests/ObservableStoreTests/ComponentMappingTests.swift
@@ -30,7 +30,9 @@ class ComponentMappingTests: XCTestCase {
             switch action {
             case .child(let action):
                 return update(
-                    cursor: ParentChildCursor.default,
+                    get: ParentChildCursor.default.get,
+                    set: ParentChildCursor.default.set,
+                    tag: ParentChildCursor.default.tag,
                     state: state,
                     action: action,
                     environment: ()
@@ -47,7 +49,9 @@ class ComponentMappingTests: XCTestCase {
                 )
             case .setText(let text):
                 var next = update(
-                    cursor: ParentChildCursor.default,
+                    get: ParentChildCursor.default.get,
+                    set: ParentChildCursor.default.set,
+                    tag: ParentChildCursor.default.tag,
                     state: state,
                     action: .setText(text),
                     environment: ()
@@ -80,7 +84,7 @@ class ComponentMappingTests: XCTestCase {
         }
     }
     
-    struct ParentChildCursor: CursorProtocol {
+    struct ParentChildCursor {
         static let `default` = ParentChildCursor()
         
         func get(_ state: ParentModel) -> ChildModel? {
@@ -101,7 +105,7 @@ class ComponentMappingTests: XCTestCase {
         }
     }
     
-    struct KeyedParentChildCursor: CursorProtocol {
+    struct KeyedParentChildCursor {
         let key: String
 
         func get(_ state: ParentModel) -> ChildModel? {
@@ -168,7 +172,9 @@ class ComponentMappingTests: XCTestCase {
     
     func testCursorUpdateTransaction() throws {
         let update = ParentModel.update(
-            cursor: ParentChildCursor.default,
+            get: ParentChildCursor.default.get,
+            set: ParentChildCursor.default.set,
+            tag: ParentChildCursor.default.tag,
             state: ParentModel(),
             action: ChildAction.setText("Foo"),
             environment: ()
@@ -221,8 +227,11 @@ class ComponentMappingTests: XCTestCase {
     }
     
     func testKeyedCursorUpdateTransaction() throws {
+        let cursor = KeyedParentChildCursor(key: "a")
         let update = ParentModel.update(
-            cursor: KeyedParentChildCursor(key: "a"),
+            get: cursor.get,
+            set: cursor.set,
+            tag: cursor.tag,
             state: ParentModel(
                 keyedChildren: [
                     "a": ChildModel(text: "A"),

--- a/Tests/ObservableStoreTests/ViewStoreTests.swift
+++ b/Tests/ObservableStoreTests/ViewStoreTests.swift
@@ -1,0 +1,143 @@
+//
+//  ViewStoreTests.swift
+//
+//
+//  Created by Gordon Brander on 9/21/22.
+//
+
+import XCTest
+import SwiftUI
+@testable import ObservableStore
+
+final class ViewStoreTests: XCTestCase {
+    enum ParentAction: Hashable {
+        case child(ChildAction)
+        case setText(String)
+    }
+    
+    struct ParentModel: ModelProtocol {
+        var child = ChildModel(text: "")
+        var edits: Int = 0
+        
+        static func update(
+            state: ParentModel,
+            action: ParentAction,
+            environment: Void
+        ) -> Update<ParentModel> {
+            switch action {
+            case .child(let action):
+                return update(
+                    get: ParentChildCursor.default.get,
+                    set: ParentChildCursor.default.set,
+                    tag: ParentChildCursor.default.tag,
+                    state: state,
+                    action: action,
+                    environment: ()
+                )
+            case .setText(let text):
+                var next = update(
+                    get: ParentChildCursor.default.get,
+                    set: ParentChildCursor.default.set,
+                    tag: ParentChildCursor.default.tag,
+                    state: state,
+                    action: .setText(text),
+                    environment: ()
+                )
+                next.state.edits = next.state.edits + 1
+                return next
+            }
+        }
+    }
+    
+    enum ChildAction: Hashable {
+        case setText(String)
+    }
+    
+    struct ChildModel: ModelProtocol {
+        var text: String
+        
+        static func update(
+            state: ChildModel,
+            action: ChildAction,
+            environment: Void
+        ) -> Update<ChildModel> {
+            switch action {
+            case .setText(let string):
+                var model = state
+                model.text = string
+                return Update(state: model)
+                    .animation(.default)
+            }
+        }
+    }
+    
+    struct ParentChildCursor {
+        static let `default` = ParentChildCursor()
+        
+        func get(_ state: ParentModel) -> ChildModel? {
+            state.child
+        }
+        
+        func set(_ state: ParentModel, _ inner: ChildModel) -> ParentModel {
+            var model = state
+            model.child = inner
+            return model
+        }
+        
+        func tag(_ action: ChildAction) -> ParentAction {
+            switch action {
+            case .setText(let string):
+                return .setText(string)
+            }
+        }
+    }
+    
+    /// Test creating binding for an address
+    func testViewStore() throws {
+        let store = Store(
+            state: ParentModel(),
+            environment: ()
+        )
+        
+        let viewStore = ViewStore(
+            state: store.state.child,
+            send: store.send,
+            tag: ParentChildCursor.default.tag
+        )
+        
+        viewStore.send(.setText("Foo"))
+        
+        XCTAssertEqual(
+            store.state.child.text,
+            "Foo"
+        )
+        XCTAssertEqual(
+            store.state.edits,
+            1
+        )
+    }
+    
+    /// Test creating binding for an address
+    func testViewStoreMethod() throws {
+        let store = Store(
+            state: ParentModel(),
+            environment: ()
+        )
+        
+        let viewStore = store.viewStore(
+            get: \.child,
+            tag: ParentChildCursor.default.tag
+        )
+        
+        viewStore.send(.setText("Foo"))
+        
+        XCTAssertEqual(
+            store.state.child.text,
+            "Foo"
+        )
+        XCTAssertEqual(
+            store.state.edits,
+            1
+        )
+    }
+}


### PR DESCRIPTION
Refinement of #24.

## Remove CursorProtocol in favor of new update method

This PR removes CursorProtocol in favor of a static `ModelProtocol.update(get:set:tag:state:action:environment)` function. This function accepts getters which return an optional state, supporting the array lookup case.

Rationale:

- Removing `CursorProtocol` is in keeping with the more "vanilla" approach to defining subcomponents introduced in #19. We don't need a special protocol or datatype when vanilla SwiftUI patterns will do. Synthesizing update functions and having two cursor types was confusing. By contrast, using closures is well-understood, and still leaves open the possibility of defining your cursor types in a separate struct.
- Passing closures makes it clearer what is happening, and leaves room to handle keyed cursors using the same API.
- Only `tag` needs to be escaping. The`get` and `set` closures have essentially no overhead.

## Re-introduce ViewStore

Brings back ViewStore with a refined API. New methods on `StoreProtocol` allow for fluent mapping between domains:

- `StoreProtocol.binding(get:tag:)` creates a binding to a sub-property.
- `StoreProtocol.viewStore(get:tag:)` creates a ViewStore for a sub-component of the store.

ViewStore no longer relies on CursorProtocol (removed), instead using simple closures to map between domains. This is more straightforward and flexible.

Additionally, it is still possible to map between component domains without using ViewStore, using `Address.forward` instead.

## Added

- `ViewStore.init(get:send:)`
- `ViewStore.init(get:send:tag:)`
- `StoreProtocol.binding(get:tag:)`
- `StoreProtocol.viewStore(get:tag:)`
- `ModelProtocol.update(get:set:tag:state:action:environment)`

## Breaking changes

- `CursorProtocol` removed
- `KeyedCursorProtocol` removed