### PR TITLE
Async/await-based effects

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "ObservableStore",
-    platforms: [.macOS(.v10_15), .iOS(.v15)],
+    platforms: [.macOS(.v13), .iOS(.v16)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -8,6 +8,8 @@ import Combine
 import SwiftUI
 
 /// An effect can be run to produce an async `Action`, and never fails.
+/// It's conceptually like a lazy `Task` which does not decide its eventual
+/// actor context.
 public struct Effect<Action: Sendable> {
     public var run: () async -> Action
     
@@ -239,10 +241,9 @@ where Model: ModelProtocol
     }
 
     /// Run an effect and send result back to store.
-    public func run(_ effect: Effect<Model.Action>) {
+    nonisolated public func run(_ effect: Effect<Model.Action>) {
         Task.detached {
-            let action = await effect.run()
-            await self.send(action)
+            await self.send(effect.run())
         }
     }
 

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -37,9 +37,9 @@ public protocol ModelProtocol: Equatable {
 }
 
 extension ModelProtocol {
-    /// Update state through a sequence of actions, merging fx.
+    /// Update state through a sequence of actions, merging effects.
     /// - State updates happen immediately
-    /// - Fx are merged
+    /// - Effects are merged
     /// - Last transaction wins
     /// This function is useful for composing actions, or when dispatching
     /// actions down to multiple child components.
@@ -103,13 +103,12 @@ extension ModelProtocol {
     }
 }
 
-/// Update represents a state change, together with an `Fx` publisher,
-/// and an optional `Transaction`.
+/// Update represents a state change, together with effects, and an
+/// optional transaction.
 public struct Update<Model: ModelProtocol> {
     /// `State` for this update
     public var state: Model
-    /// `Fx` for this update.
-    /// Default is an `Empty` publisher (no effects)
+    /// Effects for this update.
     public var effects: [Effect<Model.Action>]
     /// The transaction that should be set during this update.
     /// Store uses this value to set the transaction while updating state,
@@ -214,15 +213,6 @@ where Model: ModelProtocol
     ///
     /// This is also a good place to put long-lived services, such as keyboard
     /// listeners, since its lifetime will match the lifetime of the Store.
-    ///
-    /// Tip: if you need to publish external events to the store, such as
-    /// keyboard events, consider publishing them via a Combine Publisher on
-    /// the environment. You can subscribe to the publisher in `update`, for
-    /// example, by firing an action `onAppear`, then mapping the environment
-    /// publisher to an `fx` and returning it as part of an `Update`.
-    /// Store will hold on to the resulting `fx` publisher until it completes,
-    /// which in the case of long-lived services, could be until the
-    /// app is stopped.
     public var environment: Model.Environment
 
     public init(

--- a/Tests/ObservableStoreTests/BindingTests.swift
+++ b/Tests/ObservableStoreTests/BindingTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import SwiftUI
 @testable import ObservableStore
 
+@MainActor
 final class BindingTests: XCTestCase {
     enum Action: Hashable {
         case setText(String)

--- a/Tests/ObservableStoreTests/ComponentMappingTests.swift
+++ b/Tests/ObservableStoreTests/ComponentMappingTests.swift
@@ -10,6 +10,7 @@ import Combine
 import SwiftUI
 @testable import ObservableStore
 
+@MainActor
 class ComponentMappingTests: XCTestCase {
     enum ParentAction: Hashable {
         case child(ChildAction)

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -17,8 +17,8 @@ final class ObservableStoreTests: XCTestCase {
         }
         
         /// Services like API methods go here
-        struct Environment {
-            let logger = Logger()
+        actor Environment {
+            nonisolated let logger = Logger()
 
             func delay<Action>(
                 succeed: Action,

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -53,7 +53,7 @@ final class ObservableStoreTests: XCTestCase {
                 model.editor = editor
                 return Update(state: model)
             case .createEmptyFxThatCompletesImmediately:
-                let fx: Fx<Action> = Empty(completeImmediately: true)
+                let fx: Effect<Action> = Empty(completeImmediately: true)
                     .eraseToAnyPublisher()
                 return Update(state: state, fx: fx)
             }
@@ -299,7 +299,7 @@ final class ObservableStoreTests: XCTestCase {
         )
         
         let expectation = XCTestExpectation(
-            description: "check that update fx are merged"
+            description: "check that update effects are merged"
         )
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 import os
 @testable import ObservableStore
 
+@MainActor
 final class ObservableStoreTests: XCTestCase {
     /// App state
     struct AppModel: ModelProtocol {

--- a/Tests/ObservableStoreTests/UpdateActionsTests.swift
+++ b/Tests/ObservableStoreTests/UpdateActionsTests.swift
@@ -9,6 +9,7 @@ import ObservableStore
 import Combine
 import os
 
+@MainActor
 class UpdateActionsTests: XCTestCase {
     enum TestAction {
         case message(String)

--- a/Tests/ObservableStoreTests/UpdateActionsTests.swift
+++ b/Tests/ObservableStoreTests/UpdateActionsTests.swift
@@ -40,14 +40,14 @@ class UpdateActionsTests: XCTestCase {
                 model.text = text
                 return Update(state: model)
             case let .delayedText(text, delay):
-                let fx: Fx<Action> = Just(
+                let fx: Effect<Action> = Just(
                     Action.setText(text)
                 )
                 .delay(for: .seconds(delay), scheduler: DispatchQueue.main)
                 .eraseToAnyPublisher()
                 return Update(state: state, fx: fx)
             case let .delayedIncrement(delay):
-                let fx: Fx<Action> = Just(
+                let fx: Effect<Action> = Just(
                     Action.increment
                 )
                 .delay(for: .seconds(delay), scheduler: DispatchQueue.main)

--- a/Tests/ObservableStoreTests/ViewStoreTests.swift
+++ b/Tests/ObservableStoreTests/ViewStoreTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import SwiftUI
 @testable import ObservableStore
 
+@MainActor
 final class ViewStoreTests: XCTestCase {
     enum ParentAction: Hashable {
         case child(ChildAction)


### PR DESCRIPTION
Instead of using Combine, we can take advantage of Swift's new concurrency primitives.

Fixes #26 