### PR TITLE
Introduce ModelFactoryProtocol

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -23,6 +23,16 @@ public protocol ModelProtocol: Equatable {
     ) -> Update<Self>
 }
 
+public protocol ModelFactoryProtocol: ModelProtocol {
+    associatedtype Flags
+
+    // Create a first update
+    static func create(
+        flags: Flags,
+        environment: Environment
+    ) -> Update<Self>
+}
+
 extension ModelProtocol {
     /// Update state through a sequence of actions, merging fx.
     /// - State updates happen immediately
@@ -294,6 +304,17 @@ where Model: ModelProtocol
         }
         // Run effect
         self.subscribe(to: next.fx)
+    }
+}
+
+extension Store where Model: ModelFactoryProtocol {
+    public convenience init(
+        flags: Model.Flags,
+        environment: Model.Environment
+    ) {
+        let update = Model.create(flags: flags, environment: environment)
+        self.init(state: update.state, environment: environment)
+        self.subscribe(to: update.fx)
     }
 }
 


### PR DESCRIPTION
Allows models to be created from a static `create` function, which returns an update (allowing intial fx to be scheduled).

This also allows for full mocking of the environment for testing in cases where the model's initial state depends upon some synchronous property of the environment.

Encountered the limitation above with current ObservableStore while working on https://github.com/subconsciousnetwork/subconscious/pull/473. Some properties of the app model are initialized from UseDefaults. Ideally, these would be exposed on the environment to allow for mocking in tests.

Fixes #28 