### PR TITLE
Allow initializing first update from closure

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -208,6 +208,18 @@ where Model: ModelProtocol
         self.send(action)
     }
 
+    /// Initialize with a closure that receives environment.
+    /// Useful when performing actions once and only once upon creation
+    /// of the store.
+    public convenience init(
+        create: (Model.Environment) -> Update<Model>,
+        environment: Model.Environment
+    ) {
+        let update = create(environment)
+        self.init(state: update.state, environment: environment)
+        self.subscribe(to: update.fx)
+    }
+
     /// Subscribe to a publisher of actions, piping them through to
     /// the store.
     ///

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -196,21 +196,9 @@ where Model: ModelProtocol
         self._actions = PassthroughSubject<Model.Action, Never>()
     }
 
-    /// Initialize and send an initial action to the store.
-    /// Useful when performing actions once and only once upon creation
-    /// of the store.
-    public convenience init(
-        state: Model,
-        action: Model.Action,
-        environment: Model.Environment
-    ) {
-        self.init(state: state, environment: environment)
-        self.send(action)
-    }
-
     /// Initialize with a closure that receives environment.
-    /// Useful when performing actions once and only once upon creation
-    /// of the store.
+    /// Useful for initializing model properties from environment, and for
+    /// kicking off actions once at store creation.
     public convenience init(
         create: (Model.Environment) -> Update<Model>,
         environment: Model.Environment

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -331,6 +331,31 @@ final class ObservableStoreTests: XCTestCase {
         )
     }
     
+    func testCreateInit() throws {
+        let store = Store(
+            create: { environment in
+                let model = AppModel(count: 1)
+                let fx = Just(AppModel.Action.increment).eraseToAnyPublisher()
+                return Update(state: model, fx: fx)
+            },
+            environment: AppModel.Environment()
+        )
+        let expectation = XCTestExpectation(
+            description: "Sent fx"
+        )
+        DispatchQueue.main.async {
+            // Publisher should fire twice: once for initial state,
+            // once for state change.
+            XCTAssertEqual(
+                store.state.count,
+                2,
+                "Sent fx"
+            )
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
+    }
+
     func testActionsPublisher() throws {
         let store = Store(
             state: AppModel(),

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -318,19 +318,6 @@ final class ObservableStoreTests: XCTestCase {
         wait(for: [expectation], timeout: 0.2)
     }
     
-    func testInitialActionInit() throws {
-        let store = Store(
-            state: AppModel(),
-            action: .increment,
-            environment: AppModel.Environment()
-        )
-        XCTAssertEqual(
-            store.state.count,
-            1,
-            "action was sent to store during init"
-        )
-    }
-    
     func testCreateInit() throws {
         let store = Store(
             create: { environment in
@@ -359,7 +346,6 @@ final class ObservableStoreTests: XCTestCase {
     func testActionsPublisher() throws {
         let store = Store(
             state: AppModel(),
-            action: .increment,
             environment: AppModel.Environment()
         )
 


### PR DESCRIPTION
Introduce `init(create:environment:` convenience initializer.

Remove `init(update:action:environment:` convenience initializer.

This is an alternative to #29 for cases where we need to initialize store from an `Update`. Instead of introducing a `ModelFactoryProtocol`, we introduce a convenience initializer that takes a `create` closure.

An advantage here is that we do not have to create a `flags` type for customizing the model construction process. Instead, because we can choose which factory function is passed to `create`, we can create one-off closure factories that set the necessary properties on the model for a given view.

Additionally, this approach does not require us to specify the type signature of the Store, since Swift is able to infer the store type from the function's return type.

Fixes #28

Alternatives considered:

- #31
- #29.