### PR TITLE
Model factory `start`

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -93,6 +93,13 @@ extension ModelProtocol {
     }
 }
 
+public protocol ModelFactoryProtocol: ModelProtocol {
+    static func start(
+        state: Self,
+        environment: Self.Environment
+    ) -> Update<Self>
+}
+
 /// Update represents a state change, together with an `Fx` publisher,
 /// and an optional `Transaction`.
 public struct Update<Model: ModelProtocol> {
@@ -294,6 +301,17 @@ where Model: ModelProtocol
         }
         // Run effect
         self.subscribe(to: next.fx)
+    }
+}
+
+extension Store where Model: ModelFactoryProtocol {
+    public convenience init(
+        initial: Model,
+        environment: Model.Environment
+    ) {
+        let update = Model.start(state: initial, environment: environment)
+        self.init(state: update.state, environment: environment)
+        self.subscribe(to: update.fx)
     }
 }
 


### PR DESCRIPTION
This PR illustrates a conceived-of solution to #28. The notion is to implement a `ModelFactoryProtocol` that implements a `static start(state: Self, environment: Self.Environment) -> Update<Self>`. Essentially an opportunity to "decorate" a model and produce effects.

However, the approach may not be ideal because models that initialize properties from environment still be required to have initial values for initializing BEFORE passing to `start`. Its really not too different from the `init(state:action:environment:)` convenience initializer in this way.