### PR TITLE
Introduce Future extensions for bridging to async-await

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -10,38 +10,6 @@ import SwiftUI
 /// Fx is a publisher that publishes actions and never fails.
 public typealias Fx<Action> = AnyPublisher<Action, Never>
 
-/// Create a Combine Future from an async closure that never fails.
-/// Async actions are run in a task and fulfil the future's promise.
-public extension Future where Failure == Never {
-    convenience init(
-        priority: TaskPriority? = nil,
-        _ perform: @escaping () async -> Output
-    ) {
-        self.init { promise in
-            Task(priority: priority) {
-                let value = await perform()
-                promise(.success(value))
-            }
-        }
-    }
-}
-
-/// Create a Combine Future from an async closure that never fails.
-/// Async actions are run in a detatched task and fulfil the future's promise.
-public extension Future where Failure == Never {
-    static func detatched(
-        priority: TaskPriority? = nil,
-        perform: @escaping () async -> Output
-    ) -> Self {
-        self.init { promise in
-            Task.detached(priority: priority) {
-                let value = await perform()
-                promise(.success(value))
-            }
-        }
-    }
-}
-
 /// A model is an equatable type that knows how to create
 /// state `Updates` for itself via a static update function.
 public protocol ModelProtocol: Equatable {
@@ -164,16 +132,6 @@ public struct Update<Model: ModelProtocol> {
     ) {
         self.state = state
         self.fx = fx
-        self.transaction = Transaction(animation: animation)
-    }
-
-    public init(
-        state: Model,
-        future: Future<Model.Action, Never>,
-        animation: Animation? = nil
-    ) {
-        self.state = state
-        self.fx = future.eraseToAnyPublisher()
         self.transaction = Transaction(animation: animation)
     }
 
@@ -437,5 +395,85 @@ extension StoreProtocol {
             get: { get(self.state) },
             set: { value in self.send(tag(value)) }
         )
+    }
+}
+
+/// Create a Combine Future from an async closure that never fails.
+/// Async actions are run in a task and fulfil the future's promise.
+///
+/// This convenience init makes it easy to bridge async/await to Combine.
+/// You can call `.eraseToAnyPublisher()` on the resulting future to make it
+/// an `Fx`.
+public extension Future where Failure == Never {
+    convenience init(
+        priority: TaskPriority? = nil,
+        operation: @escaping () async -> Output
+    ) {
+        self.init { promise in
+            Task(priority: priority) {
+                let value = await operation()
+                promise(.success(value))
+            }
+        }
+    }
+}
+
+/// Create a Combine Future from an async closure that never fails.
+/// Async actions are run in a detached task and fulfil the future's promise.
+///
+/// This convenience init makes it easy to bridge async/await to Combine.
+/// You can call `.eraseToAnyPublisher()` on the resulting future to make it
+/// an `Fx`.
+public extension Future where Failure == Never {
+    static func detached(
+        priority: TaskPriority? = nil,
+        operation: @escaping () async -> Output
+    ) -> Self {
+        self.init { promise in
+            Task.detached(priority: priority) {
+                let value = await operation()
+                promise(.success(value))
+            }
+        }
+    }
+}
+
+/// Create a Combine Future from a throwing async closure.
+/// Async actions are run in a task and fulfil the future's promise.
+public extension Future where Failure == Error {
+    convenience init(
+        priority: TaskPriority? = nil,
+        operation: @escaping () async throws -> Output
+    ) {
+        self.init { promise in
+            Task(priority: priority) {
+                do {
+                    let value = try await operation()
+                    promise(.success(value))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+    }
+}
+
+/// Create a Combine Future from a throwing async closure.
+/// Async actions are run in a detached task and fulfil the future's promise.
+public extension Future where Failure == Error {
+    static func detached(
+        priority: TaskPriority? = nil,
+        operation: @escaping () async throws -> Output
+    ) -> Self {
+        self.init { promise in
+            Task.detached(priority: priority) {
+                do {
+                    let value = try await operation()
+                    promise(.success(value))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
     }
 }

--- a/Tests/ObservableStoreTests/FutureTests.swift
+++ b/Tests/ObservableStoreTests/FutureTests.swift
@@ -1,0 +1,144 @@
+//
+//  FutureTests.swift
+//  
+//
+//  Created by Gordon Brander on 4/18/23.
+//
+
+import XCTest
+import Combine
+@testable import ObservableStore
+
+final class FutureTests: XCTestCase {
+    var cancellables: Set<AnyCancellable> = Set()
+    
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation
+        // of each test method in the class.
+        
+        // Clear cancellables from last test.
+        cancellables = Set()
+    }
+    
+    enum TestServiceError: Error {
+        case interruptedByIntergalacticHighwayProject
+    }
+    
+    actor TestService {
+        func calculateMeaningOfLife() -> Int {
+            return 42
+        }
+        
+        func failToCalculateMeaningOfLife() throws -> Int {
+            throw TestServiceError.interruptedByIntergalacticHighwayProject
+        }
+    }
+    
+    func testFutureAsyncExtension() throws {
+        let service = TestService()
+        
+        let expectation = XCTestExpectation(
+            description: "Future completes successfully"
+        )
+        
+        Future {
+            await service.calculateMeaningOfLife()
+        }
+        .sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    expectation.fulfill()
+                }
+            },
+            receiveValue: { value in
+                XCTAssertEqual(value, 42)
+            }
+        )
+        .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 0.1)
+    }
+    
+    func testFutureDetachedAsyncExtension() throws {
+        let service = TestService()
+        
+        let expectation = XCTestExpectation(
+            description: "Future completes successfully"
+        )
+        
+        Future.detached {
+            await service.calculateMeaningOfLife()
+        }
+        .sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    expectation.fulfill()
+                }
+            },
+            receiveValue: { value in
+                XCTAssertEqual(value, 42)
+            }
+        )
+        .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 0.1)
+    }
+    
+    func testFutureThrowingAsyncExtension() throws {
+        let service = TestService()
+        
+        let expectation = XCTestExpectation(
+            description: "Future fails (intentional)"
+        )
+        
+        Future {
+            try await service.failToCalculateMeaningOfLife()
+        }
+        .sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    XCTFail("Future finished with success result, but should have finished with failure result of type error")
+                case .failure:
+                    expectation.fulfill()
+                }
+            },
+            receiveValue: { value in
+                XCTFail("Future should fail, and receiveValue should not be called")
+            }
+        )
+        .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 0.1)
+    }
+    
+    func testFutureDetachedThrowingAsyncExtension() throws {
+        let service = TestService()
+
+        let expectation = XCTestExpectation(
+            description: "Future fails (intentional)"
+        )
+
+        Future.detached {
+            try await service.failToCalculateMeaningOfLife()
+        }
+        .sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    XCTFail("Future finished with success result, but should have finished with failure result of type error")
+                case .failure:
+                    expectation.fulfill()
+                }
+            },
+            receiveValue: { value in
+                XCTFail("Future should fail, and receiveValue should not be called")
+            }
+        )
+        .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.1)
+    }
+}

--- a/Tests/ObservableStoreTests/UpdateTests.swift
+++ b/Tests/ObservableStoreTests/UpdateTests.swift
@@ -46,6 +46,12 @@ final class UpdateTests: XCTestCase {
     /// This test does nothing except try all initializers so Swift
     /// will complain if any of our initializers are ambiguous.
     func testInitializers() {
+        let _ = Update(
+            state: Model(),
+            fx: Just(.c).eraseToAnyPublisher(),
+            transaction: Transaction(animation: .default)
+        )
+
         let _ = Update(state: Model())
 
         let _ = Update(state: Model(), animation: .default)
@@ -57,19 +63,6 @@ final class UpdateTests: XCTestCase {
             fx: Just(.c).eraseToAnyPublisher(),
             animation: .default
         )
-
-        let future = Future {
-            do {
-                try await Task.sleep(nanoseconds: 1)
-            } catch {
-                return Action.a
-            }
-            return Action.b
-        }
-
-        let _ = Update(state: Model(), future: future)
-
-        let _ = Update(state: Model(), future: future, animation: .default)
 
         XCTAssertTrue(true)
     }

--- a/Tests/ObservableStoreTests/UpdateTests.swift
+++ b/Tests/ObservableStoreTests/UpdateTests.swift
@@ -1,0 +1,76 @@
+//
+//  UpdateTests.swift
+//  
+//
+//  Created by Gordon Brander on 4/10/23.
+//
+
+import XCTest
+import SwiftUI
+import Combine
+@testable import ObservableStore
+
+final class UpdateTests: XCTestCase {
+    enum Action: Hashable {
+        case a
+        case b
+        case c
+    }
+
+    struct Model: ModelProtocol {
+        typealias Environment = Void
+        var value: String = ""
+
+        static func update(
+            state: Self,
+            action: Action,
+            environment: Environment
+        ) -> Update<Self> {
+            switch action {
+            case .a:
+                var model = state
+                model.value = "a"
+                return Update(state: model)
+            case .b:
+                var model = state
+                model.value = "b"
+                return Update(state: model)
+            case .c:
+                var model = state
+                model.value = "c"
+                return Update(state: model)
+            }
+        }
+    }
+
+    /// This test does nothing except try all initializers so Swift
+    /// will complain if any of our initializers are ambiguous.
+    func testInitializers() {
+        let _ = Update(state: Model())
+
+        let _ = Update(state: Model(), animation: .default)
+
+        let _ = Update(state: Model(), fx: Just(.c).eraseToAnyPublisher())
+
+        let _ = Update(
+            state: Model(),
+            fx: Just(.c).eraseToAnyPublisher(),
+            animation: .default
+        )
+
+        let future = Future {
+            do {
+                try await Task.sleep(nanoseconds: 1)
+            } catch {
+                return Action.a
+            }
+            return Action.b
+        }
+
+        let _ = Update(state: Model(), future: future)
+
+        let _ = Update(state: Model(), future: future, animation: .default)
+
+        XCTAssertTrue(true)
+    }
+}


### PR DESCRIPTION
Introduces extensions to `Future` that allow you to create a Future from an async closure. This gives us a nice bridge from async swift to Combine.

Also introduce other initializers for convenience, and to make dispatch un-ambiguous:

`Update(state:fx:transaction:)`
`Update(state:animation:)`
`Update(state:fx:animation:)`

Fixes #26 by bridging async/await to Combine.

## Notes on design and tradeoffs

This PR is an alternative to #27. As mentioned in https://github.com/subconsciousnetwork/ObservableStore/pull/27#issuecomment-1491899862, there are tradeoffs with a pure async/await-based approach to Fx

- We do want combine-like publisher-subscription semantics for things like https://github.com/subconsciousnetwork/subconscious/pull/473#issuecomment-1490878422. Therefore we would need combine publisher machinery in Store anyway.
- Additionally, we need a way to batch fx. If we pursue a pure async/await based approach, leaves us carrying an array of async closures on Update.
    - Why? Because we want a collection of Action-producing asynchronous tasks/processes, all which are all run in parallel. 
    - An async sequence is no good, because we need to resolve in parallel, not in sequence.
    - So that leaves us with an array of async closures, which are run in store.
    - However, this semantics essentially describes Publishers. Going with an array of async closures does little except lose us the affordances of Combine Publishers.

One motivation for #26 was to have an explicit semantics of cancellation for long-polling tasks, by forcing them to fold into state via the update function at each step. This is good practice for the normal case. However, there are cases where this is not desired, like https://github.com/subconsciousnetwork/subconscious/pull/473#issuecomment-1490878422, or for keyboard events. Also, it is possible to cancel long-polling publishers at their source through the mechanisms publishers provide. There is no need for Store to have cancellation semantics.

A reasonable approach forward is to stick with Publishers, but to make it very convenient to bridge from async swift to Publishers. In particular, we want to make it very convenient to produce `Future<Action, Never>`, since these are one-shot Fx that always succeed and never fail, so they have the desired property that you do one fx, which produces one action, then fold into state with update.

And so, we introduce an extension to `Future` which allows you to create a Future from an async closure.