### PR TITLE
Access ViewStore state dynamically via closure

### DIFF
--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -403,6 +403,139 @@ public struct Address {
     }
 }
 
+/// A cursor provides a complete description of how to map from one component
+/// domain to another.
+public protocol CursorProtocol {
+    associatedtype Model: ModelProtocol
+    associatedtype ViewModel: ModelProtocol
+
+    /// Get an inner state from an outer state
+    static func get(state: Model) -> ViewModel
+
+    /// Set an inner state on an outer state, returning an outer state
+    static func set(state: Model, inner: ViewModel) -> Model
+
+    /// Tag an inner action, transforming it into an outer action
+    static func tag(_ action: ViewModel.Action) -> Model.Action
+}
+
+extension CursorProtocol {
+    /// Update an outer state through a cursor.
+    /// CursorProtocol.update offers a convenient way to call child
+    /// update functions from the parent domain, and get parent-domain
+    /// states and actions back from it.
+    ///
+    /// - `state` the outer state
+    /// - `action` the inner action
+    /// - `environment` the environment for the update function
+    /// - Returns a new outer state
+    @available(
+        *,
+        deprecated,
+        message: "CursorProtocol is depreacated and will be removed in a future update. Use ModelProtocol.update(get:set:tag:state:action:environment:) instead."
+    )
+    public static func update(
+        state: Model,
+        action viewAction: ViewModel.Action,
+        environment: ViewModel.Environment
+    ) -> Update<Model> {
+        let next = ViewModel.update(
+            state: get(state: state),
+            action: viewAction,
+            environment: environment
+        )
+        return Update(
+            state: set(state: state, inner: next.state),
+            fx: next.fx.map(tag).eraseToAnyPublisher(),
+            transaction: next.transaction
+        )
+    }
+}
+
+public protocol KeyedCursorProtocol {
+    associatedtype Key
+    associatedtype Model: ModelProtocol
+    associatedtype ViewModel: ModelProtocol
+
+    /// Get an inner state from an outer state
+    static func get(state: Model, key: Key) -> ViewModel?
+
+    /// Set an inner state on an outer state, returning an outer state
+    static func set(state: Model, inner: ViewModel, key: Key) -> Model
+
+    /// Tag an inner action, transforming it into an outer action
+    static func tag(action: ViewModel.Action, key: Key) -> Model.Action
+}
+
+extension KeyedCursorProtocol {
+    /// Update an inner state within an outer state through a keyed cursor.
+    /// This cursor type is useful when looking up children in dynamic lists
+    /// such as arrays or dictionaries.
+    ///
+    /// - `state` the outer state
+    /// - `action` the inner action
+    /// - `environment` the environment for the update function
+    /// - `key` a key uniquely representing this model in the parent domain
+    /// - Returns an update for a new outer state or nil
+    @available(
+        *,
+        deprecated,
+        message: "KeyedCursorProtocol is depreacated and will be removed in a future update. Use ModelProtocol.update(get:set:tag:state:action:environment:) instead."
+    )
+    public static func update(
+        state: Model,
+        action viewAction: ViewModel.Action,
+        environment viewEnvironment: ViewModel.Environment,
+        key: Key
+    ) -> Update<Model>? {
+        guard let viewModel = get(state: state, key: key) else {
+            return nil
+        }
+        let next = ViewModel.update(
+            state: viewModel,
+            action: viewAction,
+            environment: viewEnvironment
+        )
+        return Update(
+            state: set(state: state, inner: next.state, key: key),
+            fx: next.fx
+                .map({ viewAction in Self.tag(action: viewAction, key: key) })
+                .eraseToAnyPublisher(),
+            transaction: next.transaction
+        )
+    }
+
+    /// Update an inner state within an outer state through a keyed cursor.
+    /// This cursor type is useful when looking up children in dynamic lists
+    /// such as arrays or dictionaries.
+    ///
+    /// This version of update always returns an `Update`. If the child model
+    /// cannot be found at key, then it returns an update for the same state
+    /// (noop), effectively ignoring the action.
+    ///
+    /// - `state` the outer state
+    /// - `action` the inner action
+    /// - `environment` the environment for the update function
+    /// - `key` a key uniquely representing this model in the parent domain
+    /// - Returns an update for a new outer state or nil
+    public static func update(
+        state: Model,
+        action viewAction: ViewModel.Action,
+        environment viewEnvironment: ViewModel.Environment,
+        key: Key
+    ) -> Update<Model> {
+        guard let next = update(
+            state: state,
+            action: viewAction,
+            environment: viewEnvironment,
+            key: key
+        ) else {
+            return Update(state: state)
+        }
+        return next
+    }
+}
+
 extension Binding {
     /// Initialize a Binding from a store.
     /// - `get` reads the binding value.

--- a/Tests/ObservableStoreTests/ViewStoreTests.swift
+++ b/Tests/ObservableStoreTests/ViewStoreTests.swift
@@ -74,7 +74,7 @@ final class ViewStoreTests: XCTestCase {
     struct ParentChildCursor {
         static let `default` = ParentChildCursor()
         
-        func get(_ state: ParentModel) -> ChildModel? {
+        func get(_ state: ParentModel) -> ChildModel {
             state.child
         }
         
@@ -100,8 +100,8 @@ final class ViewStoreTests: XCTestCase {
         )
         
         let viewStore = ViewStore(
-            state: store.state.child,
-            send: store.send,
+            store: store,
+            get: ParentChildCursor.default.get,
             tag: ParentChildCursor.default.tag
         )
         


### PR DESCRIPTION
Update `ViewStore` so that it dynamically gets the state of the parent store using a closure. Previously we were copying state by value.

This PR updates ViewStore's state-getting approach to work the same way as Bindings. Bindings also use a `get` and `set` closure under the hood to implement bi-directional binding to a source of truth.

## Motivation and background

This is in response to an unusual bug we experienced while working on Subconscious.

Was experiencing a mysterious crasher when factoring NavigationStack into a subview. What I discovered was that, at some point, NavigationStack seems to be attempting to mutate the array that manages that stack. I believe the fact that we pass the stack down as a value type may be causing the problem. It's obscured because the issue happens in Apple's proprietary SwiftUI code. The crash had to do with an array manipulation, and seemed likely to be related to the array that manages the view stack, or perhaps it with some sort of race condition in view rendering on the SwiftUI side.

The workaround was giving NavigationStack a @State binding and replaying changes onto it.

However, this made me wonder if the cause was the fact that we passed the stack by value down the the view, before creating a Binding that referenced it.

After stubbing in a ViewStore with a Binding-like closure get function, the issue was resolved. So it seems that there are corner cases where SwiftUI needs to dynamically read the value via closure, not have it passed down by value.

### A note on SwiftUI's update strategy, and why this may be happening

> SwiftUI only tracks `@State` and `@ObservedObject` variables inside a View. More accurately, Any views that reads from `@State` var foo are invalidated whenever foo changes, wherever foo is declared, and Any views that has `@ObservedObject` var foo are invalidated whenever foo.objectWillChange is triggered. Binding is just a way to read from/write to variables across views. If you mutate to ObservableObject, it will trigger objectWillChange, but if the view that mutates it does not observe it with `@ObservedObject` the view will not be invalidated. https://forums.swift.org/t/swiftui-bindings-does-reading-them-in-body-mean-view-will-re-render/34600/2

I believe this description is correct, based on my experience with SwiftUI. So what a Binding does is providing a dynamic window into a slice of state, but Binding itself does not trigger view invalidation. Instead, mutation happens to the parent `@State`, `@StateObject`, or `@ObservedObject`, through the Binding's set closure. This invalidates the parent containing the `ObservableObject` or state, which causes its body to be re-evaluated, which will in-turn cause its children's body to be re-evaluated.

In theory, passing copies of state down, and messages up should accomplish the same kind of top-down rendering cascade. In practice, this almost always works just fine. Apple's SwiftUI tutorial shows passing down state to children by value, for example. However, in very rare edge cases, it seems to trip up. Some areas we've had to work around issues are inputs, and NavigationStack. In the case of passing down state to a child, the Apple tutorial still uses `@State` in the child view for state like inputs owned by that view... Why this should be a problem is a mystery that can probably only be explained by the closed-source internals of SwiftUI. Perhaps Apple may have some race condition around view invalidation, or something like that. Either way, using a closure to get state, the way Binding does, seems to side-step these issues.

What else does this tell us? Binding (and, by extension, ViewStore) do not optimize re-rendering. A child view with a binding will re-render any time anything in the root ObservableObject changes (Store, in our case). So we could achieve a similar effect by passing down the whole store. However, Binding and ViewStore do give us the advantage of type-erased domain-specific encapsulation.

## Other possible approaches

- There may be an opportunity to use EquatableView to customize the view diffing and make it more efficient. If we explore this path, we must take care to remember that the two instances of ObservedObject will have the same identity, so we would have to diff by another means, such as keeping the previous model state as a private property of the ViewStore.
- Another approach could be to create ObservableObjects for sub-components, and replay select events onto them from the parent store using Combine. This is the approach ComposableArchitecture takes. However, ObservableObjects must be classes, and this means re-creating a new instance of the heap-allocated class every time the parent store changes, plus any escaping closures that are needed to map the Combine publisher. I don't think this buys us much.
    - Note that ViewStore requires 2 escaping closures. These are heap-allocated too. We could alternatively use a protocol.

Pursuing the ViewStore approach because it is the most straightforward.