### PR TITLE
Log actions publicly

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "ObservableStore",
-    platforms: [.macOS(.v10_15), .iOS(.v15)],
+    platforms: [.macOS(.v11), .iOS(.v15)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -332,7 +332,8 @@ where Model: ModelProtocol
     /// run on main thread when SwiftUI is being used.
     public func send(_ action: Model.Action) {
         if loggingEnabled {
-            logger.log("Action: \(String(describing: action))")
+            let actionString = String(describing: action)
+            logger.log("Action: \(actionString, privacy: .public)")
         }
 
         // Dispatch action before state change

--- a/Sources/ObservableStore/ObservableStore.swift
+++ b/Sources/ObservableStore/ObservableStore.swift
@@ -333,7 +333,7 @@ where Model: ModelProtocol
     public func send(_ action: Model.Action) {
         if loggingEnabled {
             let actionString = String(describing: action)
-            logger.log("Action: \(actionString, privacy: .public)")
+            logger.debug("Action: \(actionString, privacy: .public)")
         }
 
         // Dispatch action before state change


### PR DESCRIPTION
It seems that logging behavior changed in XCode 15. Now strings and objects are masked private by default.

This change makes logged store actions public so that you can capture debug logs. If you enable store logging, the burden on the developer to mask sensitive data by implementing `CustomStringConvertible`.

Related to https://github.com/subconsciousnetwork/subconscious/issues/1012