### PR TITLE
Fix Fx memory leak through Publisher.flatMap

### DIFF
--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -97,6 +97,86 @@ final class ObservableStoreTests: XCTestCase {
         XCTAssertEqual(store.state.count, 1, "state is advanced")
     }
 
+    /// Tests that the immediately-completing empty Fx used as the default for
+    /// updates get removed from the cancellables array.
+    ///
+    /// Failure to remove immediately-completing fx would cause a memory leak.
+    func testEmptyFxRemovedOnComplete() {
+        let store = Store(
+            state: AppModel(),
+            environment: AppModel.Environment()
+        )
+        store.send(.increment)
+        store.send(.increment)
+        store.send(.increment)
+        let expectation = XCTestExpectation(
+            description: "cancellable removed when publisher completes"
+        )
+        DispatchQueue.main.async {
+            XCTAssertEqual(
+                store.cancellables.count,
+                0,
+                "cancellables removed when publisher completes"
+            )
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    /// Tests that immediately-completing Fx get removed from the cancellables.
+    ///
+    /// array. Failure to remove immediately-completing fx would cause a
+    /// memory leak.
+    ///
+    /// When you don't specify fx for an update, we default to
+    /// an immediately-completing `Empty` publisher, so this test is
+    /// technically the same as the one above. The difference is that it
+    /// does not rely on an implementation detail of `Update` but instead
+    /// tests this behavior directly, in case the implementation were to
+    /// change somehow.
+    func testEmptyFxThatCompleteImmiedatelyRemovedOnComplete() {
+        let store = Store(
+            state: AppModel(),
+            environment: AppModel.Environment()
+        )
+        store.send(.createEmptyFxThatCompletesImmediately)
+        store.send(.createEmptyFxThatCompletesImmediately)
+        store.send(.createEmptyFxThatCompletesImmediately)
+        let expectation = XCTestExpectation(
+            description: "cancellable removed when publisher completes"
+        )
+        DispatchQueue.main.async {
+            XCTAssertEqual(
+                store.cancellables.count,
+                0,
+                "cancellables removed when publisher completes"
+            )
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    func testAsyncFxRemovedOnComplete() {
+        let store = Store(
+            state: AppModel(),
+            environment: AppModel.Environment()
+        )
+        store.send(.delayIncrement(0.1))
+        store.send(.delayIncrement(0.2))
+        let expectation = XCTestExpectation(
+            description: "cancellable removed when publisher completes"
+        )
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            XCTAssertEqual(
+                store.cancellables.count,
+                0,
+                "cancellables removed when publisher completes"
+            )
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.5)
+    }
+
     func testPublishedPropertyFires() throws {
         let store = Store(
             state: AppModel(),


### PR DESCRIPTION
Fix memory leak introduced through use of `Publisher.flatMap` to manage Fx. It turns out that flatMap keeps publishers from disposed stores alive, introducing a retain cycle!

I couldn't believe it at first, since I would have believed flatMap would clean up publishers after they complete, but it seems no?

Anyway, the fix was to go back to manually managed fx lifetimes instead of using flatMap. Tested in app, this resolved the issue.