### PR TITLE
Change StoreProtocol to implement `transaction`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "ObservableStore",
-    platforms: [.macOS(.v11), .iOS(.v15)],
+    platforms: [.macOS(.v11), .iOS(.v16)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Tests/ObservableStoreTests/BindingTests.swift
+++ b/Tests/ObservableStoreTests/BindingTests.swift
@@ -50,7 +50,7 @@ final class BindingTests: XCTestCase {
         
         let binding = Binding(
             get: { store.state.text },
-            send: store.send,
+            transact: store.transact,
             tag: Action.setText
         )
         

--- a/Tests/ObservableStoreTests/ComponentMappingTests.swift
+++ b/Tests/ObservableStoreTests/ComponentMappingTests.swift
@@ -133,7 +133,7 @@ class ComponentMappingTests: XCTestCase {
         )
         
         let send = Address.forward(
-            send: store.send,
+            send: store.transact,
             tag: ParentChildCursor.default.tag
         )
         
@@ -161,8 +161,8 @@ class ComponentMappingTests: XCTestCase {
             ),
             environment: ()
         )
-        store.send(.keyedChild(action: .setText("BBB"), key: "a"))
-        store.send(.keyedChild(action: .setText("AAA"), key: "a"))
+        store.transact(.keyedChild(action: .setText("BBB"), key: "a"))
+        store.transact(.keyedChild(action: .setText("AAA"), key: "a"))
 
         XCTAssertEqual(
             store.state.keyedChildren["a"]?.text,
@@ -191,8 +191,8 @@ class ComponentMappingTests: XCTestCase {
             state: ParentModel(),
             environment: ()
         )
-        store.send(.setText("Woo"))
-        store.send(.setText("Woo"))
+        store.transact(.setText("Woo"))
+        store.transact(.setText("Woo"))
 
         XCTAssertEqual(
             store.state.child.text,

--- a/Tests/ObservableStoreTests/ObservableStoreTests.swift
+++ b/Tests/ObservableStoreTests/ObservableStoreTests.swift
@@ -92,8 +92,8 @@ final class ObservableStoreTests: XCTestCase {
             environment: AppModel.Environment()
         )
         
-        store.send(.increment)
-        
+        store.transact(.increment)
+
         XCTAssertEqual(store.state.count, 1, "state is advanced")
     }
 
@@ -139,9 +139,9 @@ final class ObservableStoreTests: XCTestCase {
             state: AppModel(),
             environment: AppModel.Environment()
         )
-        store.send(.createEmptyFxThatCompletesImmediately)
-        store.send(.createEmptyFxThatCompletesImmediately)
-        store.send(.createEmptyFxThatCompletesImmediately)
+        store.transact(.createEmptyFxThatCompletesImmediately)
+        store.transact(.createEmptyFxThatCompletesImmediately)
+        store.transact(.createEmptyFxThatCompletesImmediately)
         let expectation = XCTestExpectation(
             description: "cancellable removed when publisher completes"
         )
@@ -221,11 +221,11 @@ final class ObservableStoreTests: XCTestCase {
             })
             .store(in: &cancellables)
         
-        store.send(.setCount(10))
-        store.send(.setCount(10))
-        store.send(.setCount(10))
-        store.send(.setCount(10))
-        
+        store.transact(.setCount(10))
+        store.transact(.setCount(10))
+        store.transact(.setCount(10))
+        store.transact(.setCount(10))
+
         let expectation = XCTestExpectation(
             description: "publisher does not fire when state does not change"
         )
@@ -357,10 +357,10 @@ final class ObservableStoreTests: XCTestCase {
             })
             .store(in: &cancellables)
         
-        store.send(.setCount(1))
-        store.send(.setCount(2))
-        store.send(.setCount(3))
-        
+        store.transact(.setCount(1))
+        store.transact(.setCount(2))
+        store.transact(.setCount(3))
+
         let expectation = XCTestExpectation(
             description: "actions publisher fires for every action"
         )

--- a/Tests/ObservableStoreTests/ViewStoreTests.swift
+++ b/Tests/ObservableStoreTests/ViewStoreTests.swift
@@ -105,7 +105,7 @@ final class ViewStoreTests: XCTestCase {
             tag: ParentChildCursor.default.tag
         )
         
-        viewStore.send(.setText("Foo"))
+        viewStore.transact(.setText("Foo"))
 
         XCTAssertEqual(
             store.state.child.text,
@@ -129,7 +129,7 @@ final class ViewStoreTests: XCTestCase {
             tag: ParentChildCursor.default.tag
         )
         
-        viewStore.send(.setText("Foo"))
+        viewStore.transact(.setText("Foo"))
         
         XCTAssertEqual(
             store.state.child.text,


### PR DESCRIPTION
...rather than send.

- `transact(:)` is a non-isolated method that performs a synchronous state transaction in response to an action.
- `send(:)` becomes an asynchronous main actor isolated protocol extension that guarantees your changes will always happen on the main thread, but offers only a fire-and-forget interface.